### PR TITLE
Support for TAK Server Federation

### DIFF
--- a/cloudformation/lib/elb.js
+++ b/cloudformation/lib/elb.js
@@ -43,6 +43,12 @@ export default {
                     IpProtocol: 'tcp',
                     FromPort: 8089,
                     ToPort: 8089
+                },{
+                    Description: 'ELB Traffic',
+                    SourceSecurityGroupId: cf.ref('ELBSecurityGroup'),
+                    IpProtocol: 'tcp',
+                    FromPort: 9001,
+                    ToPort: 9001
                 }]
             }
         },
@@ -100,6 +106,11 @@ export default {
                     IpProtocol: 'tcp',
                     FromPort: 8089,
                     ToPort: 8089
+                },{
+                    CidrIp: '0.0.0.0/0',
+                    IpProtocol: 'tcp',
+                    FromPort: 9001,
+                    ToPort: 9001
                 }],
                 VpcId: cf.importValue(cf.join(['coe-base-', cf.ref('Environment'), '-vpc-id']))
             }

--- a/docker-container/scripts/CoreConfig.ts
+++ b/docker-container/scripts/CoreConfig.ts
@@ -73,6 +73,18 @@ const LDAP_Auth = {
     LDAP_RoleAttribute: process.env.TAKSERVER_CoreConfig_Auth_LDAP_RoleAttribute || 'takRole'
 };
 
+const Federation = {
+    EnableFederation: stringToBoolean(process.env.TAKSERVER_CoreConfig_Federation_EnableFederation) || true,
+    AllowFederatedDelete: stringToBoolean(process.env.TAKSERVER_CoreConfig_Federation_AllowFederatedDelete) || false,
+    AllowMissionFederation: stringToBoolean(process.env.TAKSERVER_CoreConfig_Federation_AllowMissionFederation) || true,
+    AllowDataFeedFederation: stringToBoolean(process.env.TAKSERVER_CoreConfig_Federation_AllowDataFeedFederation) || true,
+    EnableMissionFederationDisruptionTolerance: stringToBoolean(process.env.TAKSERVER_CoreConfig_Federation_EnableMissionFederationDisruptionTolerance) || true,
+    MissionFederationDisruptionToleranceRecencySeconds: parseInt(process.env.TAKSERVER_CoreConfig_Federation_MissionFederationDisruptionToleranceRecencySeconds) || 43200,
+    EnableDataPackageAndMissionFileFilter: stringToBoolean(process.env.TAKSERVER_CoreConfig_Federation_EnableDataPackageAndMissionFileFilter) || false,
+    Federation_WebBaseUrl: process.env.TAKSERVER_CoreConfig_Federation_WebBaseUrl || 'https://localhost:8443/Marti'
+};
+
+
 const RemoteCoreConfig: Static<typeof CoreConfigType> | null = null;
 let CoreConfig: Static<typeof CoreConfigType> | null = null;
 
@@ -309,6 +321,57 @@ if (!CoreConfig) {
                         keystoreFile: '/opt/tak/certs/files/truststore-root.jks',
                         keystorePass: 'atakatak'
                     }
+                }
+            },
+            federation: {
+                _attributes: {
+                    allowFederatedDelete: Federation.AllowFederatedDelete,
+                    allowMissionFederation: Federation.AllowMissionFederation,
+                    allowDataFeedFederation: Federation.AllowDataFeedFederation,
+                    enableMissionFederationDisruptionTolerance: Federation.EnableMissionFederationDisruptionTolerance,
+                    missionFederationDisruptionToleranceRecencySeconds: Federation.MissionFederationDisruptionToleranceRecencySeconds,
+                    enableFederation: Federation.EnableFederation,
+                    enableDataPackageAndMissionFileFilter: Federation.EnableDataPackageAndMissionFileFilter
+                },
+                'federation-server': {
+                    _attributes: {
+                        port: 9000,
+                        coreVersion: 2,
+                        v1enabled: false,
+                        v2port: 9001,
+                        v2enabled: true,
+                        webBaseUrl: Federation.Federation_WebBaseUrl,
+                    },
+                    tls: {
+                        _attributes: {
+                            keystore: 'JKS',
+                            keystoreFile: '/opt/tak/certs/files/takserver.jks',
+                            keystorePass: 'atakatak',
+                            truststore: 'JKS',
+                            truststoreFile: '/opt/tak/certs/files/fed-truststore.jks',
+                            truststorePass: 'atakatak',
+                            context: 'TLSv1.2',
+                            keymanager: 'SunX509'
+                        }
+                    },
+                    'federation-port': {
+                        _attributes: {
+                            port: 9000,
+                            tlsVersion: 'TLSv1.2'
+                        }
+                    },
+                    v1Tls: [{
+                        _attributes: {
+                            tlsVersion: 'TLSv1.2'
+                        }
+                    },{
+                        _attributes: {
+                            tlsVersion: 'TLSv1.3'
+                        }
+                    }]
+                },
+                fileFilter: {
+                    fileExtension: ['pref']
                 }
             },
             plugins: {},

--- a/docker-container/scripts/start
+++ b/docker-container/scripts/start
@@ -15,12 +15,10 @@ if [ -d "/opt/tak/certs/files/" ]; then
     mkdir -p "/opt/tak/certs/files/"
 fi
 
-# Attempt to restore Certbot Cronjob or save it, if it exists
+# Attempt to restore Certbot Cronjob
 echo "ok - Certbot - Restoring cronjob"
 if [ ! -e "/etc/cron.d/certbot" ]; then
     cp /etc/letsencrypt/certbot.cron /etc/cron.d/certbot || true
-else
-    cp /etc/cron.d/certbot /etc/letsencrypt/certbot.cron || true
 fi
 
 # Check if TAK certs exist, otherwise generate them
@@ -47,7 +45,9 @@ fi
 # Restore certs for self-enrollment (HTTPS on TCP/8446)
 # Check if certs for self-enrollment (HTTPS on TCP/8446) exist
 mkdir /opt/tak/certs/files/${TAKSERVER_QuickConnect_LetsEncrypt_Domain} || true
-if [ -d "/etc/letsencrypt/live/${TAKSERVER_QuickConnect_LetsEncrypt_Domain}" ]; then
+if [[ -d "/etc/letsencrypt/live/${TAKSERVER_QuickConnect_LetsEncrypt_Domain}" && \
+    ( "${TAKSERVER_QuickConnect_LetsEncrypt_CertType}" == "Production" || "${TAKSERVER_QuickConnect_LetsEncrypt_CertType}" == "Staging" ) \
+    ]]; then
     # Previous LetsEncrypt cert exists, convert it to JKS format
     echo "ok - TAK Server - Converting LetsEncrypt certs to TAK format"
     openssl x509 \
@@ -71,7 +71,7 @@ if [ -d "/etc/letsencrypt/live/${TAKSERVER_QuickConnect_LetsEncrypt_Domain}" ]; 
         -srckeystore "/opt/tak/certs/files/${TAKSERVER_QuickConnect_LetsEncrypt_Domain}/letsencrypt.p12" \
         -srcstoretype "pkcs12" 
 else 
-    # No previous LetsEncrypt cert exists, use the self-signed one instead
+    # No previous LetsEncrypt cert exists or settings call for none to be used, use the self-signed one instead
     echo "ok - TAK Server - Using self-signed certs instead of LetsEncrypt certs"
     cp /opt/tak/certs/files/takserver.jks /opt/tak/certs/files/${TAKSERVER_QuickConnect_LetsEncrypt_Domain}/letsencrypt.jks || true
 fi

--- a/takserver-config.env.example
+++ b/takserver-config.env.example
@@ -44,16 +44,33 @@ TAKSERVER_CoreConfig_Auth_X509useGroupCacheDefaultActive=true
 # Valid: true, false
 TAKSERVER_CoreConfig_Auth_X509checkRevocation=true
 # Base DN will be appended automatically
-TAKSERVER_CoreConfig_Auth_LDAP_Userstring="cn={username},ou=users,"
+TAKSERVER_CoreConfig_Auth_LDAP_Userstring=cn={username},ou=users,
 TAKSERVER_CoreConfig_Auth_LDAP_Updateinterval=60
-TAKSERVER_CoreConfig_Auth_LDAP_Groupprefix="cn=tak_"
-TAKSERVER_CoreConfig_Auth_LDAP_GroupNameExtractorRegex="cn=tak_(.*?)(?:,|$)"
+TAKSERVER_CoreConfig_Auth_LDAP_Groupprefix=cn=tak_
+TAKSERVER_CoreConfig_Auth_LDAP_GroupNameExtractorRegex=cn=tak_(.*?)(?:,|$)
 TAKSERVER_CoreConfig_Auth_LDAP_Style=DS
 # Base DN will be appended automatically
-TAKSERVER_CoreConfig_Auth_LDAP_ServiceAccountDN="cn=ldapservice,ou=users,"
-TAKSERVER_CoreConfig_Auth_LDAP_GroupObjectClass="groupOfNames"
+TAKSERVER_CoreConfig_Auth_LDAP_ServiceAccountDN=cn=ldapservice,ou=users,
+TAKSERVER_CoreConfig_Auth_LDAP_GroupObjectClass=groupOfNames
 # Base DN will be appended automatically
-TAKSERVER_CoreConfig_Auth_LDAP_GroupBaseRDN="ou=group,"
-TAKSERVER_CoreConfig_Auth_LDAP_CallsignAttribute="takCallsign"
-TAKSERVER_CoreConfig_Auth_LDAP_ColorAttribute="takColor"
-TAKSERVER_CoreConfig_Auth_LDAP_RoleAttribute="takRole"
+TAKSERVER_CoreConfig_Auth_LDAP_GroupBaseRDN=ou=group,
+TAKSERVER_CoreConfig_Auth_LDAP_CallsignAttribute=takCallsign
+TAKSERVER_CoreConfig_Auth_LDAP_ColorAttribute=takColor
+TAKSERVER_CoreConfig_Auth_LDAP_RoleAttribute=takRole
+
+# Federation Configuration
+# Valid: true, false
+TAKSERVER_CoreConfig_Federation_EnableFederation=true
+# Valid: true, false
+TAKSERVER_CoreConfig_Federation_AllowFederatedDelete=false
+# Valid: true, false
+TAKSERVER_CoreConfig_Federation_AllowMissionFederation=true
+# Valid: true, false
+TAKSERVER_CoreConfig_Federation_AllowDataFeedFederation=true
+# Valid: true, false
+TAKSERVER_CoreConfig_Federation_EnableMissionFederationDisruptionTolerance=true
+TAKSERVER_CoreConfig_Federation_MissionFederationDisruptionToleranceRecencySeconds=43200
+# Valid: true, false
+TAKSERVER_CoreConfig_Federation_EnableDataPackageAndMissionFileFilter=false
+TAKSERVER_CoreConfig_Federation_WebBaseUrl=https://ops.dev.tak.nz:8443/Marti
+


### PR DESCRIPTION
* **Federation Support:** Supportes configuration of TAK Server federation over port TCP/9001. Configuration is done via .env file.