### PR TITLE
OAuth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,36 @@
-<h1 align=center>TAK Infrastructure</h1>
+<h1 align=center>TAK Server Infra</h1>
 
-<p align=center>CloudFormation managed infrastructure for TAK Server</p>
+<p align=center>CloudFormation managed infrastructure for TAK Server on Docker containers</p>
 
-## AWS Deployment
+## Background
 
-### 1. Pre-Requisites
+The [Team Awareness Kit (TAK)](https://tak.gov/solutions/emergency) provides Fire, Emergency Management, and First Responders an operationally agnostic tool for improved situational awareness and a common operational picture. 
+This repo deploys the base infrastructure required to deploy a [TAK server](https://tak.gov/solutions/emergency) along with [Authentik](https://goauthentik.io/) as the authentication layer on AWS.
+
+## Pre-Reqs
 
 > [!IMPORTANT]
-> The TAK service assumes several pre-requisite dependencies are deployed before
-> initial TAK Server deployment.
+> The Auth-Infra service assumes some pre-requisite dependencies are deployed before
+> initial deployment.
 
-The following are dependencies which need to be created:
+The following dependencies must be fulfilled:
+- An [AWS Account](https://signin.aws.amazon.com/signup?request_type=register).
+- A Domain Name under which the TAK server is made available, e.g. `tak.nz` in the example here.
+- An [AWS ACM certificate](https://docs.aws.amazon.com/acm/latest/userguide/gs.html) certificate.
+  - This certificate should cover the main domain - e.g. `tak.nz`, as well as two levels of wildcard subdomains, e.g. `*.tak.nz` and `*.*.tak.nz`.
+
+The following stack layers need to be created before deploying this layer:
 
 | Name                  | Notes |
 | --------------------- | ----- |
-| `coe-vpc-<name>`      | VPC & networking to place tasks in - [repo](https://github.com/dfpc-coe/vpc) |
-| `coe-ecs-<name>`      | ECS Cluster for API Service - [repo](https://github.com/dfpc-coe/ecs) |
-| `coe-ecr-tak`         | ECR Repository for storing Server Images - [repo](https://github.com/dfpc-coe/ecr)     |
+| `coe-base-<name>`      | VPC, ECS cluster, and ECR repository - [repo](https://github.com/TAK-NZ/base-infra)      |
+| `coe-auth-<name>`     | Authentication layer using Authentik - [repo](https://github.com/TAK-NZ/auth-infra)      |
 
-### 2. Install Tooling Dependencies
+
+
+## AWS Deployment
+
+### 1. Install Tooling Dependencies
 
 From the root directory, install the deploy dependencies
 
@@ -26,39 +38,25 @@ From the root directory, install the deploy dependencies
 npm install
 ```
 
+### 2.(Optional) TAK Server configuration
+
+The `coe-base-<name>` layer creates an S3 bucket with the name `coe-auth-config-s3-<name>-<region>-env-config` which can be used for TAK Server configuration via an .env configuration file.
+An example configuration file with the name [takserver-config.env.example] is provided in this repo. Adjust this file based on your needs and store it in the created S3 bucket as `takserver-config.env`.
+
 ### 3. Building Docker Images & Pushing to ECR
 
 An script to build docker images and publish them to your ECR is provided and can be run using:
 
 ```
-npm run build
+npm run build -- --env devtest
 ```
 
-from the root of the project. Ensure that you have created the necessary ECR repositories as described in the
-previous step and that you have AWS credentials provided in your current terminal environment as an `aws ecr get-login-password`
-call will be issued.
+from the root of the project. The script supports additional parameters for deploying the docker container into ECR into a specific region or using a specific AWS account profile.
 
 ### 4. CloudFormation Stack Deployment
 Deployment to AWS is handled via AWS Cloudformation. The templates can be found in the `./cloudformation`
 directory. The deployment itself is performed by [Deploy](https://github.com/openaddresses/deploy) which
 was installed in the previous step.
-
-> [!NOTE] 
-> The deploy tool can be run via the following
->
-> ```sh
-> npx deploy
-> ```
->
-> To install it globally - view the deploy [README](https://github.com/openaddresses/deploy)
->
-> Deploy uses your existing AWS credentials. Ensure that your `~/.aws/credentials` has an entry like:
-> 
-> ```
-> [coe]
-> aws_access_key_id = <redacted>
-> aws_secret_access_key = <redacted>
-> ```
 
 #### Sub-Stack Deployment
 
@@ -67,30 +65,54 @@ The CloudFormation is split into two stacks to ensure consistent deploy results.
 The first portion deploys the ELB, database and all necessary related filestore
 components. The second portion deploys the ECS Service itself.
 
-Step 1: Create Network Portion:
+It is important that this layer is deployed into an existing `base-infra` stack.
+
+**Step 1:** Create Network Portion:
 
 ```
 npx deploy create <stack> --template ./cloudformation/network.template.js
 ```
 
-Step 2: Setup a DNS CNAME from your desired hostname for the TAK server to the ELB hostname. The ELB hostname is one of the CloudFormation template outputs. 
+**Step 2:** Setup a DNS CNAME from your desired hostname for the TAK server to the ELB hostname. The ELB hostname is one of the CloudFormation template outputs. An example would be `ops.tak.nz` as the hostname for the TAK server.
 
-Step3: Create Service Portion (Once DNS been set & propagated)
+**Step3:** Create Service Portion (Once DNS been set & propagated)
 
 ```
 npx deploy create <stack>
 ```
-> [!NOTE] 
-> Stacks can be created, deleted, cancelled, etc all via the deploy tool. For further information
-> information about `deploy` functionality run the following for help.
-> 
-> ```sh
-> npx deploy
-> ```
-> 
-> Further help about a specific command can be obtained via something like:
-> 
-> ```sh
-> npx deploy info --help
-> ```
 
+## About the deploy tool
+
+The deploy tool can be run via the `npx deploy` command.
+
+To install it globally - view the deploy [README](https://github.com/openaddresses/deploy)
+
+Deploy uses your existing AWS credentials. Ensure that your `~/.aws/credentials` has an entry like:
+ 
+```
+[coe]
+aws_access_key_id = <redacted>
+aws_secret_access_key = <redacted>
+```
+
+Stacks can be created, deleted, cancelled, etc all via the deploy tool. For further information
+information about `deploy` functionality run the following for help.
+ 
+```sh
+npx deploy
+```
+ 
+Further help about a specific command can be obtained via something like:
+
+```sh
+npx deploy info --help
+```
+
+## Estimated Cost
+
+The estimated AWS cost for this layer of the stack without data transfer or data processing based usage is:
+
+| Environment type      | Estimated monthly cost | Estimated yearly cost |
+| --------------------- | ----- | ----- |
+| Prod                  | 366.87 USD | 4,402.44 USD |
+| Dev-Test              | 106.25 USD | 1,275.00 USD |

--- a/docker-container/scripts/CoreConfig.ts
+++ b/docker-container/scripts/CoreConfig.ts
@@ -94,11 +94,12 @@ const OAuth = {
     OauthUseGroupCache: stringToBoolean(process.env.TAKSERVER_CoreConfig_OAuth_OauthUseGroupCache || 'false'),
     LoginWithEmail: stringToBoolean(process.env.TAKSERVER_CoreConfig_OAuth_LoginWithEmail || 'false'),
     UseTakServerLoginPage: stringToBoolean(process.env.TAKSERVER_CoreConfig_OAuth_UseTakServerLoginPage || 'false'),
-    GroupsClaim: process.env.TAKSERVER_CoreConfig_OAuth_GroupsClaim || 'groups',
+    GroupsClaim: process.env.TAKSERVER_CoreConfig_OAuth_GroupsClaim,
     UsernameClaim: process.env.TAKSERVER_CoreConfig_OAuth_UsernameClaim,
-    ScopeClaim: process.env.TAKSERVER_CoreConfig_OAuth_ScopeClaim || 'scope',
+    ScopeClaim: process.env.TAKSERVER_CoreConfig_OAuth_ScopeClaim,
     WebtakScope: process.env.TAKSERVER_CoreConfig_OAuth_WebtakScope,
     Groupprefix: process.env.TAKSERVER_CoreConfig_OAuth_Groupprefix,
+    AllowUriQueryParameter: stringToBoolean(process.env.TAKSERVER_CoreConfig_OAuth_AllowUriQueryParameter || 'false'),
     OAuthServerName: process.env.TAKSERVER_CoreConfig_OAuthServer_Name,
     OAuthServerIssuer: process.env.TAKSERVER_CoreConfig_OAuthServer_Issuer,
     OAuthServerClientId: process.env.TAKSERVER_CoreConfig_OAuthServer_ClientId,
@@ -107,8 +108,8 @@ const OAuth = {
     OAuthServerScope: process.env.TAKSERVER_CoreConfig_OAuthServer_Scope,
     OAuthServerAuthEndpoint: process.env.TAKSERVER_CoreConfig_OAuthServer_AuthEndpoint,
     OAuthServerTokenEndpoint: process.env.TAKSERVER_CoreConfig_OAuthServer_TokenEndpoint,
-    OAuthServerAccessTokenName: process.env.TAKSERVER_CoreConfig_OAuthServer_AccessTokenName || 'access_token',
-    OAuthServerRefreshTokenName: process.env.TAKSERVER_CoreConfig_OAuthServer_RefreshTokenName || 'refresh_token',
+    OAuthServerAccessTokenName: process.env.TAKSERVER_CoreConfig_OAuthServer_AccessTokenName,
+    OAuthServerRefreshTokenName: process.env.TAKSERVER_CoreConfig_OAuthServer_RefreshTokenName,
     OAuthServerTrustAllCerts: stringToBoolean(process.env.TAKSERVER_CoreConfig_OAuthServer_TrustAllCerts || 'false')
 };
 
@@ -225,14 +226,15 @@ if (!CoreConfig) {
                 ...(OAuth.OAuthServerName && OAuth.OAuthServerIssuer && OAuth.OAuthServerClientId && OAuth.OAuthServerSecret && OAuth.OAuthServerRedirectUri && OAuth.OAuthServerAuthEndpoint && OAuth.OAuthServerTokenEndpoint) && ({
                     oauth: {
                         _attributes: {
-                            oauthUseGroupCache: OAuth.OauthUseGroupCache,
-                            loginWithEmail: OAuth.LoginWithEmail,
-                            useTakServerLoginPage: OAuth.UseTakServerLoginPage,
-                            groupsClaim: OAuth.GroupsClaim,
+                            ...(OAuth.OauthUseGroupCache && { oauthUseGroupCache: OAuth.OauthUseGroupCache }),
+                            ...(OAuth.LoginWithEmail && { loginWithEmail: OAuth.LoginWithEmail }),
+                            ...(OAuth.UseTakServerLoginPage && { useTakServerLoginPage: OAuth.UseTakServerLoginPage }),
+                            ...(OAuth.GroupsClaim && { groupsClaim: OAuth.GroupsClaim }),
                             ...(OAuth.UsernameClaim && { usernameClaim: OAuth.UsernameClaim }),
-                            scopeClaim: OAuth.ScopeClaim,
+                            ...(OAuth.ScopeClaim && { scopeClaim: OAuth.ScopeClaim }),
                             ...(OAuth.WebtakScope && { webtakScope: OAuth.WebtakScope }),
-                            ...(OAuth.Groupprefix && { groupprefix: OAuth.Groupprefix })
+                            ...(OAuth.Groupprefix && { groupprefix: OAuth.Groupprefix }),
+                            ...(OAuth.AllowUriQueryParameter && { allowUriQueryParameter: OAuth.AllowUriQueryParameter })
                         },
                         authServer: {
                             _attributes: {
@@ -244,9 +246,9 @@ if (!CoreConfig) {
                                 authEndpoint: OAuth.OAuthServerAuthEndpoint,
                                 ...(OAuth.OAuthServerScope && { scope: OAuth.OAuthServerScope }),
                                 tokenEndpoint: OAuth.OAuthServerTokenEndpoint,
-                                accessTokenName: OAuth.OAuthServerAccessTokenName,
-                                refreshTokenName: OAuth.OAuthServerRefreshTokenName,
-                                trustAllCerts: OAuth.OAuthServerTrustAllCerts
+                                ...(OAuth.OAuthServerAccessTokenName && { accessTokenName: OAuth.OAuthServerAccessTokenName }),
+                                ...(OAuth.OAuthServerRefreshTokenName && { refreshTokenName: OAuth.OAuthServerRefreshTokenName }),
+                                ...(OAuth.OAuthServerTrustAllCerts && { trustAllCerts: OAuth.OAuthServerTrustAllCerts })
                             }
                         }
                     }

--- a/docker-container/scripts/getOIDCIssuerPubKey.sh
+++ b/docker-container/scripts/getOIDCIssuerPubKey.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Define the JWKS URL from the TAK Server configuration
+jwks_url="${TAKSERVER_CoreConfig_OAuthServer_JWKS}"
+
+# Fetch the JWKS data
+jwks_data=$(curl -s "$jwks_url")
+
+# Extract the x5c value
+x5c_value=$(echo "$jwks_data" | jq -r '.keys[0].x5c[0]')
+
+# Format the certificate
+formatted_cert="-----BEGIN CERTIFICATE-----
+$x5c_value
+-----END CERTIFICATE-----"
+
+# Convert the certificate for use with TAK Server
+echo "ok - TAK Server - Downloading OIDC issuer public certificate from $jwks_url"
+echo "$formatted_cert" | openssl x509 -pubkey -noout  > ${TAKSERVER_CoreConfig_OAuthServer_Issuer}
+
+
+
+

--- a/docker-container/scripts/start
+++ b/docker-container/scripts/start
@@ -86,6 +86,15 @@ fi
 # Request LetsEncrypt certs in background
 /opt/tak/scripts/letsencrypt-request-cert.sh &
 
+# Download OIDC issuer public certificate if configured
+if [ -n "${TAKSERVER_CoreConfig_OAuthServer_JWKS:-}" ] && [ -n "${TAKSERVER_CoreConfig_OAuthServer_Issuer:-}" ]; then
+    echo "ok - TAK Server - Downloading OIDC issuer public certificate"
+    /opt/tak/scripts/getOIDCIssuerPubKey.sh
+else
+    echo "ok - TAK Server - No OIDC issuer public certificate configured, skipping download"
+fi
+
+
 echo "ok - TAK Server - Generating config file"
 cd /opt/tak
 npx tsx /opt/tak/scripts/CoreConfig.ts

--- a/docker-container/scripts/start
+++ b/docker-container/scripts/start
@@ -24,12 +24,18 @@ fi
 # Check if TAK certs exist, otherwise generate them
 cd /opt/tak/certs
 if [ ! -f "/opt/tak/certs/files/ca.pem" ]; then
-    echo "ok - TAK Server - Generating new certificates"
+    echo "ok - TAK Server - Generating new certificates..."
     echo "ok - TAK Server - CA Country: ${TAKSERVER_CACert_Country:=NZ}"
     echo "ok - TAK Server - CA State: ${TAKSERVER_CACert_State:=Wellington}"
     echo "ok - TAK Server - CA City: ${TAKSERVER_CACert_City:=Wellington}"
     echo "ok - TAK Server - CA Organization: ${TAKSERVER_CACert_Org:=TAK.NZ}"
     echo "ok - TAK Server - CA Organizational Unit: ${TAKSERVER_CACert_OrgUnit:=TAK.NZ Operations}" 
+    export COUNTRY=${TAKSERVER_CACert_Country}
+    export STATE=${TAKSERVER_CACert_State}
+    export CITY=${TAKSERVER_CACert_City}
+    export ORGANIZATION=${TAKSERVER_CACert_Org}
+    export ORGANIZATIONAL_UNIT=${TAKSERVER_CACert_OrgUnit}
+    sed -i -e 's/COUNTRY=US/COUNTRY=${COUNTRY}/' /opt/tak/certs/cert-metadata.sh
     /opt/tak/certs/cert-metadata.sh
     mkdir -p "/opt/tak/certs/files/${TAKSERVER_QuickConnect_LetsEncrypt_Domain:=nodomainset}/"
     /opt/tak/certs/makeRootCa.sh --ca-name ${TAKSERVER_CACert_Org}

--- a/docker/amd64/Dockerfile.takserver
+++ b/docker/amd64/Dockerfile.takserver
@@ -3,7 +3,7 @@ LABEL org.opencontainers.image.source=https://github.com/tak-nz/takserver
 LABEL org.opencontainers.image.description="TAK server for deployment with AWS ECS"
 LABEL org.opencontainers.image.licenses=MIT
 RUN apt update \
-    && apt-get install -y cron emacs-nox net-tools vim certbot curl libxml2-utils unzip zip nodejs awscli
+    && apt-get install -y cron emacs-nox net-tools vim certbot curl libxml2-utils unzip zip nodejs awscli jq
 
 ENV HOME=/opt/tak
 WORKDIR $HOME

--- a/docker/amd64/Dockerfile.takserver-tak-nz
+++ b/docker/amd64/Dockerfile.takserver-tak-nz
@@ -3,7 +3,7 @@ LABEL org.opencontainers.image.source=https://github.com/tak-nz/takserver
 LABEL org.opencontainers.image.description="TAK server for deployment with AWS ECS"
 LABEL org.opencontainers.image.licenses=MIT
 RUN apt update \
-    && apt-get install -y cron emacs-nox net-tools vim certbot curl libxml2-utils unzip zip nodejs awscli
+    && apt-get install -y cron emacs-nox net-tools vim certbot curl libxml2-utils unzip zip nodejs awscli jq
 
 ENV HOME=/opt/tak
 WORKDIR $HOME

--- a/takserver-config.env.example
+++ b/takserver-config.env.example
@@ -76,3 +76,17 @@ TAKSERVER_CoreConfig_Federation_MissionFederationDisruptionToleranceRecencySecon
 TAKSERVER_CoreConfig_Federation_EnableDataPackageAndMissionFileFilter=false
 TAKSERVER_CoreConfig_Federation_WebBaseUrl=https://ops.dev.tak.nz:8443/Marti
 
+#OAuth Server Support
+TAKSERVER_CoreConfig_OAuth_OauthUseGroupCache=true
+TAKSERVER_CoreConfig_OAuth_LoginWithEmail=true
+TAKSERVER_CoreConfig_OAuth_UseTakServerLoginPage=false
+TAKSERVER_CoreConfig_OAuth_UsernameClaim=preferred_username
+TAKSERVER_CoreConfig_OAuthServer_Name=TAK.NZ Account
+TAKSERVER_CoreConfig_OAuthServer_Scope=openid profile
+TAKSERVER_CoreConfig_OAuthServer_Issuer=/opt/tak/certs/files/oauth-public-key.pem
+TAKSERVER_CoreConfig_OAuthServer_JWKS=https://account.tak.nz/application/o/tak-server/jwks/
+TAKSERVER_CoreConfig_OAuthServer_ClientId=abcdefg12345
+TAKSERVER_CoreConfig_OAuthServer_Secret=mysupersecretsecret
+TAKSERVER_CoreConfig_OAuthServer_RedirectUri=https://ops.tak.nz:8446/login/redirect
+TAKSERVER_CoreConfig_OAuthServer_AuthEndpoint=https://account.tak.nz/application/o/authorize/
+TAKSERVER_CoreConfig_OAuthServer_TokenEndpoint=https://account.tak.nz/application/o/token/


### PR DESCRIPTION
Added support for OAuth via .env config file. The sample config file has been updated. 

Notes:
* TAK server expects the CA certificate of the OAuth server as the issuer. This certificate is usually available via the JWKS endpoint from OIDC Identity Providers. As such an embedded script will download the cert from the JWKS endpoint and convert it into the right format. 

* TAK server does not support single logout/end-session, even if the IdP supports it. Also as it uses it's own auth cookie even after logout from the IdP you might still be logged in to WebTAK. A solution would be to flush all domain cookies on logout. 