### PR TITLE
feat: use S3 TAK Images bucket instead of wget for TAK server downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,18 @@ This TAK Server infrastructure requires the base infrastructure and authenticati
 - Public Route 53 hosted zone (e.g., `tak.nz`)
 - [Node.js](https://nodejs.org/) and npm installed
 - Development tools: `libxml2-utils` for XML validation (see [Deployment Guide](docs/DEPLOYMENT_GUIDE.md#development-environment-setup))
-- **TAK Server Distribution**: Download `takserver-docker-<version>.zip` from https://tak.gov/products/tak-server and place it in the root directory of this repository
+- **TAK Server Distribution**: Download `takserver-docker-<version>.zip` from https://tak.gov/products/tak-server and either:
+  - Place it in the root directory of this repository, OR
+  - Upload it to the S3 TAK Images bucket (exported as `TAK-<n>-BaseInfra-S3TAKImagesArn`)
 
 ### Installation & Deployment
 
 ```bash
 # 1. Download TAK Server distribution
 # Download takserver-docker-<version>.zip from https://tak.gov/products/tak-server
-# Place the file in the root directory of this repository
+# Either:
+#   - Place the file in the root directory of this repository, OR
+#   - Upload to S3 bucket (see TAK Server Distribution section below)
 
 # 2. Install dependencies
 npm install
@@ -135,6 +139,28 @@ This stack uses **AWS CDK's built-in Docker image assets** for automatic contain
 ### Docker Images Used
 
 1. **TAK Server**: Built from `docker/tak-server/Dockerfile.{branding}`
+
+### TAK Server Distribution
+
+The TAK Server Docker images require the official TAK Server distribution file. You have two options:
+
+#### Option 1: Local Repository (Default)
+Place `takserver-docker-<version>.zip` in the root directory of this repository.
+
+#### Option 2: S3 Bucket (Recommended for CI/CD)
+Upload the TAK Server distribution to the S3 bucket created by BaseInfra:
+
+```bash
+# Get the S3 bucket name from CloudFormation export
+BUCKET_ARN=$(aws cloudformation describe-stacks --stack-name TAK-<n>-BaseInfra \
+  --query 'Stacks[0].Outputs[?OutputKey==`S3TAKImagesArn`].OutputValue' --output text)
+BUCKET_NAME=$(echo $BUCKET_ARN | sed 's|arn:aws:s3:::|s3://|')
+
+# Upload TAK Server distribution
+aws s3 cp takserver-docker-5.4-RELEASE-19.zip $BUCKET_NAME/
+```
+
+**Note**: The Docker build process will automatically check the local repository first, then fall back to downloading from S3 if the file is not found locally.
 
 ### Branding Support
 

--- a/docker/tak-server/Dockerfile.tak-nz
+++ b/docker/tak-server/Dockerfile.tak-nz
@@ -3,6 +3,7 @@ LABEL org.opencontainers.image.source=https://github.com/tak-nz/takserver
 LABEL org.opencontainers.image.description="TAK server for deployment with AWS ECS"
 LABEL org.opencontainers.image.licenses=MIT
 ARG TAK_VERSION=takserver-docker-5.4-RELEASE-19
+ARG ENVIRONMENT
 RUN apt update \
     && apt-get install -y net-tools netcat \
         tini cron certbot curl libxml2-utils unzip zip awscli jq \
@@ -18,7 +19,7 @@ COPY ./takserver-docker-*.zip $HOME/
 ENV TAK_VERSION=${TAK_VERSION}
 
 RUN if [ ! -e "${TAK_VERSION}.zip" ]; then \
-        wget "http://tak-server-releases.s3-website.us-gov-east-1.amazonaws.com/${TAK_VERSION}.zip"; \
+        aws s3 cp "s3://$(aws cloudformation describe-stacks --stack-name TAK-${ENVIRONMENT}-BaseInfra --query 'Stacks[0].Outputs[?OutputKey==`S3TAKImagesArn`].OutputValue' --output text | sed 's|arn:aws:s3:::|s3://|')/${TAK_VERSION}.zip" "${TAK_VERSION}.zip"; \
     fi \
     && unzip "./${TAK_VERSION}.zip" \
     && rm "./${TAK_VERSION}.zip" \

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -9,6 +9,7 @@
 - Public Route 53 hosted zone for your domain
 - Node.js 18+ and npm installed
 - Development tools (see [Development Environment Setup](#development-environment-setup) below)
+- **TAK Server Distribution**: `takserver-docker-<version>.zip` either in repository root OR uploaded to S3 TAK Images bucket
 
 ### **One-Command Deployment**
 ```bash
@@ -141,11 +142,19 @@ git clone <repository-url>
 cd tak-infra
 npm install
 
-# 2. Set environment variables (if using AWS profiles)
+# 2. Prepare TAK Server distribution (choose one option):
+# Option A: Place takserver-docker-<version>.zip in repository root
+# Option B: Upload to S3 TAK Images bucket:
+#   BUCKET_ARN=$(aws cloudformation describe-stacks --stack-name TAK-<n>-BaseInfra \
+#     --query 'Stacks[0].Outputs[?OutputKey==`S3TAKImagesArn`].OutputValue' --output text)
+#   BUCKET_NAME=$(echo $BUCKET_ARN | sed 's|arn:aws:s3:::|s3://|')
+#   aws s3 cp takserver-docker-5.4-RELEASE-19.zip $BUCKET_NAME/
+
+# 3. Set environment variables (if using AWS profiles)
 export CDK_DEFAULT_ACCOUNT=$(aws sts get-caller-identity --query Account --output text --profile your-profile)
 export CDK_DEFAULT_REGION=$(aws configure get region --profile your-profile)
 
-# 3. Deploy TAK Server infrastructure
+# 4. Deploy TAK Server infrastructure
 npm run deploy:dev -- --context stackName=YourStackName
 ```
 

--- a/lib/cloudformation-imports.ts
+++ b/lib/cloudformation-imports.ts
@@ -19,6 +19,7 @@ export const BASE_EXPORT_NAMES = {
   KMS_KEY: 'KmsKeyArn',
   KMS_ALIAS: 'KmsAlias',
   S3_BUCKET: 'S3BucketArn',
+  S3_TAK_IMAGES: 'S3TAKImagesArn',
   S3_ID: 'S3-ID',
   CERTIFICATE_ARN: 'CertificateArn',
   HOSTED_ZONE_ID: 'HostedZoneId',

--- a/lib/constructs/tak-server.ts
+++ b/lib/constructs/tak-server.ts
@@ -285,7 +285,8 @@ export class TakServer extends Construct {
       directory: '.',
       file: `docker/tak-server/${dockerfileName}`,
       buildArgs: {
-        TAK_VERSION: `takserver-docker-${props.contextConfig.takserver.version}`
+        TAK_VERSION: `takserver-docker-${props.contextConfig.takserver.version}`,
+        ENVIRONMENT: props.contextConfig.stackName
       },
       // Exclude files that change frequently but don't affect the Docker build
       exclude: [


### PR DESCRIPTION
# Use S3 TAK Images bucket for TAK server distribution downloads

Replaces hardcoded wget URL with dynamic S3 bucket lookup using BaseInfra CloudFormation export `TAK-<n>-BaseInfra-S3TAKImagesArn`.

## Changes
- **Dockerfile**: Replace wget with AWS CLI using CloudFormation export lookup
- **TAK Server construct**: Pass ENVIRONMENT build arg for stack name resolution  
- **CloudFormation imports**: Add S3_TAK_IMAGES constant for new export
- **Documentation**: Add S3 upload instructions and maintain consistency with `TAK-<n>-BaseInfra` naming

## Benefits
- Eliminates hardcoded S3 website URL dependency
- Supports CI/CD workflows with centralized TAK distribution storage
- Maintains backward compatibility with local file placement
- Uses proper CloudFormation exports for infrastructure coupling

## Testing
- [X] Verify Docker build works with local takserver-docker-*.zip file
- [X] Verify Docker build downloads from S3 when local file missing
- [X] Confirm CloudFormation export resolution works correctly
