### PR TITLE
Fix ECS Permissions and Let's Encrypt Certificate Issues

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -87,7 +87,7 @@ jobs:
           echo "tak-tag=$TAK_TAG" >> $GITHUB_OUTPUT
 
       - name: Deploy Demo with Prod Profile
-        run: npm run cdk deploy -- --context envType=prod --context stackName=${{ vars.STACK_NAME }} --context usePreBuiltImages=true --context takImageTag=${{ steps.images.outputs.tak-tag }} --require-approval never
+        run: npm run cdk deploy -- --context envType=prod --context stackName=${{ vars.STACK_NAME }} --context letsEncryptMode=production --context usePreBuiltImages=true --context takImageTag=${{ steps.images.outputs.tak-tag }} --require-approval never
 
       - name: Wait for Testing Period
         run: sleep ${{ vars.DEMO_TEST_DURATION || '300' }}
@@ -121,4 +121,4 @@ jobs:
         run: npm run cdk synth -- --context envType=dev-test --context stackName=${{ vars.STACK_NAME }}
 
       - name: Revert Demo to Dev-Test Profile
-        run: npm run cdk deploy -- --context envType=dev-test --context stackName=${{ vars.STACK_NAME }} --context usePreBuiltImages=true --context takImageTag=${{ needs.deploy-and-test.outputs.tak-tag }} --require-approval never
+        run: npm run cdk deploy -- --context envType=dev-test --context stackName=${{ vars.STACK_NAME }} --context letsEncryptMode=production --context usePreBuiltImages=true --context takImageTag=${{ needs.deploy-and-test.outputs.tak-tag }} --require-approval never

--- a/lib/constructs/tak-server.ts
+++ b/lib/constructs/tak-server.ts
@@ -239,7 +239,8 @@ export class TakServer extends Construct {
     taskRole.addToPolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
       actions: [
-        'ecs:UpdateService'
+        'ecs:UpdateService',
+        'ecs:DescribeServices'
       ],
       resources: [
         `arn:aws:ecs:${Stack.of(this).region}:${Stack.of(this).account}:service/${props.infrastructure.ecsCluster.clusterName}/${Stack.of(this).stackName}-TakServer`


### PR DESCRIPTION
# Fix ECS Permissions and Let's Encrypt Certificate Issues

## Problem
- TAK Server container failing with `AccessDeniedException` when checking ECS service status during Let's Encrypt certificate requests
- Demo workflow switching between prod/dev-test modes causing unnecessary certificate re-requests, hitting Let's Encrypt rate limits

## Solution
- **ECS Permissions**: Add `ecs:DescribeServices` permission to TAK Server task role
- **Certificate Consistency**: Use `letsEncryptMode=production` in both demo deployment modes

## Changes
- `lib/constructs/tak-server.ts`: Add `ecs:DescribeServices` to existing ECS policy
- `.github/workflows/demo-deploy.yml`: Add `--context letsEncryptMode=production` to both deployment steps

## Result
- Let's Encrypt certificate management works without permission errors
- Demo environment maintains same certificate across configuration switches
- Avoids Let's Encrypt rate limiting issues
