### PR TITLE
Fix LetsEncrypt Certificate Handling Issues

### DIFF
--- a/docker-container/scripts/letsencrypt-request-cert.sh
+++ b/docker-container/scripts/letsencrypt-request-cert.sh
@@ -105,13 +105,21 @@ if [[ -z "${TAKSERVER_QuickConnect_LetsEncrypt_Domain+x}" || \
     ( "${TAKSERVER_QuickConnect_LetsEncrypt_CertType,,}" != "production" && "${TAKSERVER_QuickConnect_LetsEncrypt_CertType,,}" != "staging" ) \
     ]]; then
     echo "TAK Server - Using self-signed certs instead of LetsEncrypt certs"
+    
+    # Clean up any existing LetsEncrypt certificates if switching away from LetsEncrypt
+    if [[ -n "${TAKSERVER_QuickConnect_LetsEncrypt_Domain:-}" && -f "/etc/letsencrypt/live/${TAKSERVER_QuickConnect_LetsEncrypt_Domain}/fullchain.pem" ]]; then
+        echo "Certbot - Cleaning up existing LetsEncrypt certificates"
+        certbot delete --cert-name "${TAKSERVER_QuickConnect_LetsEncrypt_Domain}" --non-interactive || true
+        trigger_ecs_deployment
+    fi
+    
     mkdir -p "/opt/tak/certs/files/nodomainset" || true
     cp "/opt/tak/certs/files/takserver.jks" "/opt/tak/certs/files/nodomainset/letsencrypt.jks" || true        
     exit 0
 fi
 
 # If LetsEncrypt certs are present - check validity
-if [ -d "/etc/letsencrypt/live/${TAKSERVER_QuickConnect_LetsEncrypt_Domain}" ]; then
+if [ -f "/etc/letsencrypt/live/${TAKSERVER_QuickConnect_LetsEncrypt_Domain}/fullchain.pem" ]; then
     echo "Certbot - Checking validity of existing certs for domain ${TAKSERVER_QuickConnect_LetsEncrypt_Domain}"
 
     # Extract the issuer from the certificate
@@ -138,48 +146,119 @@ if [ -d "/etc/letsencrypt/live/${TAKSERVER_QuickConnect_LetsEncrypt_Domain}" ]; 
     esac
 fi
 
-# Function to check ECS service readiness
+# Function to check ECS service readiness and ensure this task is the only one receiving traffic
 check_ecs_service_ready() {
     local max_wait_time=${ECS_READINESS_TIMEOUT:-900}
     local check_interval=30
     local max_attempts=$((max_wait_time / check_interval))
     
-    echo "Certbot - Waiting for ECS service (timeout: ${max_wait_time}s)..."
+    echo "Certbot - Waiting for ECS service and load balancer readiness (timeout: ${max_wait_time}s)..."
     
     for i in $(seq 1 $max_attempts); do
-        local service_status
-        if ! service_status=$(aws ecs describe-services \
+        # Step 1: Check exactly 1 task is running
+        local running_count
+        if ! running_count=$(aws ecs describe-services \
             --cluster "${ECS_Cluster_Name}" \
             --services "${ECS_Service_Name}" \
-            --query 'services[0].deployments[?status==`PRIMARY`].runningCount' \
+            --query 'services[0].runningCount' \
             --output text 2>/tmp/aws_error.log); then
             
             echo "Warning: Failed to check ECS service status"
-            echo "AWS CLI Error:"
             cat /tmp/aws_error.log
-            return 1
+            sleep $check_interval
+            continue
         fi
         
-        if [[ "$service_status" =~ ^[0-9]+$ ]] && [ "$service_status" -gt 0 ]; then
-            echo "Certbot - ECS service ready after $((i * check_interval))s"
+        if [[ "$running_count" != "1" ]]; then
+            echo "Certbot - Waiting for exactly 1 running task (current: $running_count)..."
+            sleep $check_interval
+            continue
+        fi
+        
+        # Step 2: Get this task's private IP
+        local task_arn
+        if ! task_arn=$(aws ecs list-tasks \
+            --cluster "${ECS_Cluster_Name}" \
+            --service-name "${ECS_Service_Name}" \
+            --query 'taskArns[0]' \
+            --output text 2>/tmp/aws_error.log); then
+            
+            echo "Warning: Failed to get task ARN"
+            cat /tmp/aws_error.log
+            sleep $check_interval
+            continue
+        fi
+        
+        local task_ip
+        if ! task_ip=$(aws ecs describe-tasks \
+            --cluster "${ECS_Cluster_Name}" \
+            --tasks "$task_arn" \
+            --query 'tasks[0].attachments[0].details[?name==`privateIPv4Address`].value' \
+            --output text 2>/tmp/aws_error.log); then
+            
+            echo "Warning: Failed to get task IP"
+            cat /tmp/aws_error.log
+            sleep $check_interval
+            continue
+        fi
+        
+        # Step 3: Find the HTTP target group (certbot target group)
+        local target_group_arn
+        if ! target_group_arn=$(aws elbv2 describe-target-groups \
+            --names "tak-*-certbot" \
+            --query 'TargetGroups[0].TargetGroupArn' \
+            --output text 2>/tmp/aws_error.log); then
+            
+            echo "Warning: Failed to find certbot target group"
+            cat /tmp/aws_error.log
+            sleep $check_interval
+            continue
+        fi
+        
+        # Step 4: Check if this task is healthy in target group
+        local healthy_targets
+        if ! healthy_targets=$(aws elbv2 describe-target-health \
+            --target-group-arn "$target_group_arn" \
+            --query 'TargetHealthDescriptions[?TargetHealth.State==`healthy`].Target.Id' \
+            --output text 2>/tmp/aws_error.log); then
+            
+            echo "Warning: Failed to check target health"
+            cat /tmp/aws_error.log
+            sleep $check_interval
+            continue
+        fi
+        
+        # Step 5: Verify only this task's IP is healthy
+        local healthy_count=$(echo "$healthy_targets" | wc -w)
+        if [[ "$healthy_count" -eq 1 && "$healthy_targets" == "$task_ip" ]]; then
+            echo "Certbot - ECS service ready: 1 task running, this task ($task_ip) is sole healthy target"
             return 0
         fi
         
-        if [[ "$service_status" == "None" ]] && [ $i -gt 5 ]; then
-            echo "Certbot - ECS service not found, continuing anyway..."
-            return 0
-        fi
-        
-        echo "Certbot - ECS service not ready, waiting ${check_interval}s... (${i}/${max_attempts})"
+        echo "Certbot - Waiting for load balancer: healthy_targets=[$healthy_targets], this_task=$task_ip"
         sleep $check_interval
     done
     
-    echo "Certbot - ECS service check timed out after ${max_wait_time}s, proceeding anyway..."
+    echo "Certbot - Load balancer check timed out, falling back to basic ECS check..."
+    
+    # Fallback to original simple check
+    local service_status
+    if service_status=$(aws ecs describe-services \
+        --cluster "${ECS_Cluster_Name}" \
+        --services "${ECS_Service_Name}" \
+        --query 'services[0].deployments[?status==`PRIMARY`].runningCount' \
+        --output text 2>/dev/null) && [[ "$service_status" =~ ^[0-9]+$ ]] && [ "$service_status" -gt 0 ]; then
+        
+        echo "Certbot - Proceeding with basic readiness check (load balancer verification failed)"
+        return 0
+    fi
+    
+    echo "Certbot - Service not ready after ${max_wait_time}s, proceeding anyway..."
     return 0
 }
 
 # If no LetsEncrypt certs are present - either because they never were or they were just removed - generate a set
-if [ ! -d "/etc/letsencrypt/live/${TAKSERVER_QuickConnect_LetsEncrypt_Domain}" ]; then
+if [ ! -f "/etc/letsencrypt/live/${TAKSERVER_QuickConnect_LetsEncrypt_Domain}/fullchain.pem" ]; then
     echo "Certbot - No existing certificates detected - Requesting new one for domain ${TAKSERVER_QuickConnect_LetsEncrypt_Domain}"
 
     # Validate certbot command before proceeding

--- a/lib/constructs/tak-server.ts
+++ b/lib/constructs/tak-server.ts
@@ -240,11 +240,24 @@ export class TakServer extends Construct {
       effect: iam.Effect.ALLOW,
       actions: [
         'ecs:UpdateService',
-        'ecs:DescribeServices'
+        'ecs:DescribeServices',
+        'ecs:ListTasks',
+        'ecs:DescribeTasks'
       ],
       resources: [
-        `arn:aws:ecs:${Stack.of(this).region}:${Stack.of(this).account}:service/${props.infrastructure.ecsCluster.clusterName}/${Stack.of(this).stackName}-TakServer`
+        `arn:aws:ecs:${Stack.of(this).region}:${Stack.of(this).account}:service/${props.infrastructure.ecsCluster.clusterName}/${Stack.of(this).stackName}-TakServer`,
+        `arn:aws:ecs:${Stack.of(this).region}:${Stack.of(this).account}:task/${props.infrastructure.ecsCluster.clusterName}/*`
       ]
+    }));
+
+    // Add load balancer permissions for Certbot readiness checks
+    taskRole.addToPolicy(new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: [
+        'elasticloadbalancing:DescribeTargetGroups',
+        'elasticloadbalancing:DescribeTargetHealth'
+      ],
+      resources: ['*']
     }));
 
     // Grant read access to S3 configuration bucket for environment files


### PR DESCRIPTION
# Fix LetsEncrypt Certificate Handling Issues

## Problem
Certbot certificate requests were failing due to multiple issues:
- Rate limiting from Let's Encrypt due to repeated failed HTTP-01 challenges
- Certificate transitions (staging ↔ production) not working properly
- Race conditions during ECS deployments preventing proper traffic routing
- Missing cleanup when switching certificate types

## Root Cause
The primary issue was that during ECS service updates, multiple tasks could be running simultaneously, causing Let's Encrypt HTTP-01 challenges to be routed to old tasks that weren't running Certbot.

## Solution
### Enhanced ECS Readiness Checks
- Improved `check_ecs_service_ready()` to ensure exactly 1 task is running
- Added load balancer target group verification to confirm this container is the sole recipient of HTTP traffic
- Added graceful fallback to original logic if enhanced checks fail

### Fixed Certificate Transitions
- Changed from directory-based to file-based certificate validation
- Fixed staging → production transitions that were previously broken
- Added proper certificate cleanup when switching to self-signed certificates

### Improved Error Handling
- Added robust error handling with graceful fallbacks for all certificate operations
- Added race condition prevention between foreground and background certificate processes
- Enhanced logging and diagnostics for troubleshooting

### IAM Permissions
- Added required permissions for ECS task inspection (`ecs:ListTasks`, `ecs:DescribeTasks`)
- Added load balancer permissions (`elasticloadbalancing:DescribeTargetGroups`, `elasticloadbalancing:DescribeTargetHealth`)

## Testing
- ✅ New certificate requests (production/staging)
- ✅ Certificate type transitions (staging ↔ production) 
- ✅ Switching to/from self-signed certificates
- ✅ Error recovery and graceful fallbacks

## Files Changed
- `docker-container/scripts/letsencrypt-request-cert.sh` - Enhanced readiness checks and certificate handling
- `docker-container/scripts/start-tak.sh` - Fixed certificate validation and conversion logic
- `lib/constructs/tak-server.ts` - Added required IAM permissions

This should resolve the Let's Encrypt certificate request failures and ensure reliable certificate management across all scenarios.
