### PR TITLE
Add CloudFormation Exports for TAK Resources

### DIFF
--- a/lib/tak-infra-stack.ts
+++ b/lib/tak-infra-stack.ts
@@ -302,5 +302,19 @@ export class TakInfraStack extends cdk.Stack {
       description: 'EFS File System ID',
       exportName: `${resolvedStackName}-EfsFileSystemId`
     });
+
+    // TAK Server Admin Certificate Secret ARN
+    new CfnOutput(this, 'TakAdminCertSecretArn', {
+      value: takSecrets.adminCertificate.secretArn,
+      description: 'TAK Server Admin Certificate (p12) Secret ARN',
+      exportName: `${resolvedStackName}-TakAdminCertSecretArn`
+    });
+
+    // TAK Service Name (hostname without https://)
+    new CfnOutput(this, 'TakServiceName', {
+      value: route53.serviceFqdn,
+      description: 'TAK Service fully qualified hostname (without https://)',
+      exportName: `${resolvedStackName}-TakServiceName`
+    });
   }
 }


### PR DESCRIPTION
### Changes
- **TakAdminCertSecretArn**: Exports the Secrets Manager ARN for TAK Server Admin Certificate (p12)
- **TakServiceName**: Exports the fully qualified hostname without `https://` prefix

### Export Names
- `TAK-{envName}-TakInfra-TakAdminCertSecretArn`
- `TAK-{envName}-TakInfra-TakServiceName`

### Example Values
- Admin Cert Secret: `TAK-Demo-TakInfra/TAK-Server/Admin-Cert`
- Service Name: `ops.demo.tak.nz`

These exports enable other stacks to reference TAK infrastructure resources.
