### PR TITLE
Add Database Context Override for Production Deployments

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -86,8 +86,20 @@ jobs:
           
           echo "tak-tag=$TAK_TAG" >> $GITHUB_OUTPUT
 
+      - name: Configure Database Context
+        id: db-config
+        run: |
+          COMMIT_MSG="${{ github.event.head_commit.message }}"
+          if [[ "$COMMIT_MSG" != *"[use-prod-db]"* ]]; then
+            echo "🔄 Using dev-test database settings for faster deployment"
+            echo "db-context=--context instanceClass=db.serverless --context instanceCount=1 --context enablePerformanceInsights=false --context monitoringInterval=0 --context backupRetentionDays=7 --context deleteProtection=false" >> $GITHUB_OUTPUT
+          else
+            echo "🚀 Using production database settings"
+            echo "db-context=" >> $GITHUB_OUTPUT
+          fi
+
       - name: Deploy Demo with Prod Profile
-        run: npm run cdk deploy -- --context envType=prod --context stackName=${{ vars.STACK_NAME }} --context letsEncryptMode=production --context usePreBuiltImages=true --context takImageTag=${{ steps.images.outputs.tak-tag }} --require-approval never
+        run: npm run cdk deploy -- --context envType=prod --context stackName=${{ vars.STACK_NAME }} --context letsEncryptMode=production --context usePreBuiltImages=true --context takImageTag=${{ steps.images.outputs.tak-tag }} ${{ steps.db-config.outputs.db-context }} --require-approval never
 
       - name: Wait for Testing Period
         run: sleep ${{ vars.DEMO_TEST_DURATION || '300' }}


### PR DESCRIPTION
## Add Database Context Override for Production Deployments

### Problem
Production deployments with full database settings (db.t4g.large, 2 instances, performance insights) take significantly longer than necessary for most CI/CD testing scenarios.

### Solution
- **Default**: Production deployments now use lightweight dev-test database settings
- **Override**: Include `[use-prod-db]` in commit message to use full production database

### Changes
- Added database context configuration step in demo-deploy workflow
- Uses context overrides: `instanceClass=db.serverless`, `instanceCount=1`, etc.
- No CDK code changes required

### Usage
- **Fast deployment**: `"feat: add feature"` → serverless DB
- **Full prod**: `"feat: add feature [use-prod-db]"` → production DB

### Benefits
- Faster CI/CD pipeline execution
- Lower testing costs
- Explicit control when full production database is needed
