### PR TITLE
Fix: Type Conversion Error for CLI Context Parameters

### DIFF
--- a/lib/utils/context-overrides.ts
+++ b/lib/utils/context-overrides.ts
@@ -20,22 +20,22 @@ export function applyContextOverrides(
     database: {
       ...baseConfig.database,
       instanceClass: app.node.tryGetContext('instanceClass') ?? baseConfig.database.instanceClass,
-      instanceCount: app.node.tryGetContext('instanceCount') ?? baseConfig.database.instanceCount,
+      instanceCount: parseContextNumber(app.node.tryGetContext('instanceCount')) ?? baseConfig.database.instanceCount,
       engineVersion: app.node.tryGetContext('engineVersion') ?? baseConfig.database.engineVersion,
-      allocatedStorage: app.node.tryGetContext('allocatedStorage') ?? baseConfig.database.allocatedStorage,
-      maxAllocatedStorage: app.node.tryGetContext('maxAllocatedStorage') ?? baseConfig.database.maxAllocatedStorage,
-      enablePerformanceInsights: app.node.tryGetContext('enablePerformanceInsights') ?? baseConfig.database.enablePerformanceInsights,
-      monitoringInterval: app.node.tryGetContext('monitoringInterval') ?? baseConfig.database.monitoringInterval,
-      backupRetentionDays: app.node.tryGetContext('backupRetentionDays') ?? baseConfig.database.backupRetentionDays,
-      deleteProtection: app.node.tryGetContext('deleteProtection') ?? baseConfig.database.deleteProtection,
+      allocatedStorage: parseContextNumber(app.node.tryGetContext('allocatedStorage')) ?? baseConfig.database.allocatedStorage,
+      maxAllocatedStorage: parseContextNumber(app.node.tryGetContext('maxAllocatedStorage')) ?? baseConfig.database.maxAllocatedStorage,
+      enablePerformanceInsights: parseContextBoolean(app.node.tryGetContext('enablePerformanceInsights')) ?? baseConfig.database.enablePerformanceInsights,
+      monitoringInterval: parseContextNumber(app.node.tryGetContext('monitoringInterval')) ?? baseConfig.database.monitoringInterval,
+      backupRetentionDays: parseContextNumber(app.node.tryGetContext('backupRetentionDays')) ?? baseConfig.database.backupRetentionDays,
+      deleteProtection: parseContextBoolean(app.node.tryGetContext('deleteProtection')) ?? baseConfig.database.deleteProtection,
     },
     ecs: {
       ...baseConfig.ecs,
-      taskCpu: app.node.tryGetContext('taskCpu') ?? baseConfig.ecs.taskCpu,
-      taskMemory: app.node.tryGetContext('taskMemory') ?? baseConfig.ecs.taskMemory,
-      desiredCount: app.node.tryGetContext('desiredCount') ?? baseConfig.ecs.desiredCount,
-      enableDetailedLogging: app.node.tryGetContext('enableDetailedLogging') ?? baseConfig.ecs.enableDetailedLogging,
-      enableEcsExec: app.node.tryGetContext('enableEcsExec') ?? baseConfig.ecs.enableEcsExec,
+      taskCpu: parseContextNumber(app.node.tryGetContext('taskCpu')) ?? baseConfig.ecs.taskCpu,
+      taskMemory: parseContextNumber(app.node.tryGetContext('taskMemory')) ?? baseConfig.ecs.taskMemory,
+      desiredCount: parseContextNumber(app.node.tryGetContext('desiredCount')) ?? baseConfig.ecs.desiredCount,
+      enableDetailedLogging: parseContextBoolean(app.node.tryGetContext('enableDetailedLogging')) ?? baseConfig.ecs.enableDetailedLogging,
+      enableEcsExec: parseContextBoolean(app.node.tryGetContext('enableEcsExec')) ?? baseConfig.ecs.enableEcsExec,
     },
     takserver: {
       ...baseConfig.takserver,
@@ -43,26 +43,47 @@ export function applyContextOverrides(
       servicename: app.node.tryGetContext('takServerServicename') ?? baseConfig.takserver.servicename,
       branding: app.node.tryGetContext('branding') ?? baseConfig.takserver.branding,
       version: app.node.tryGetContext('takServerVersion') ?? baseConfig.takserver.version,
-      useS3TAKServerConfigFile: app.node.tryGetContext('useS3TAKServerConfigFile') ?? baseConfig.takserver.useS3TAKServerConfigFile,
+      useS3TAKServerConfigFile: parseContextBoolean(app.node.tryGetContext('useS3TAKServerConfigFile')) ?? baseConfig.takserver.useS3TAKServerConfigFile,
       letsEncryptMode: app.node.tryGetContext('letsEncryptMode') ?? baseConfig.takserver.letsEncryptMode,
       letsEncryptEmail: app.node.tryGetContext('letsEncryptEmail') ?? baseConfig.takserver.letsEncryptEmail,
-      enableFederation: app.node.tryGetContext('enableFederation') ?? baseConfig.takserver.enableFederation,
-      enableCloudWatchMetrics: app.node.tryGetContext('enableCloudWatchMetrics') ?? baseConfig.takserver.enableCloudWatchMetrics,
+      enableFederation: parseContextBoolean(app.node.tryGetContext('enableFederation')) ?? baseConfig.takserver.enableFederation,
+      enableCloudWatchMetrics: parseContextBoolean(app.node.tryGetContext('enableCloudWatchMetrics')) ?? baseConfig.takserver.enableCloudWatchMetrics,
     },
     ecr: {
       ...baseConfig.ecr,
-      imageRetentionCount: app.node.tryGetContext('imageRetentionCount') ?? baseConfig.ecr.imageRetentionCount,
-      scanOnPush: app.node.tryGetContext('scanOnPush') ?? baseConfig.ecr.scanOnPush,
+      imageRetentionCount: parseContextNumber(app.node.tryGetContext('imageRetentionCount')) ?? baseConfig.ecr.imageRetentionCount,
+      scanOnPush: parseContextBoolean(app.node.tryGetContext('scanOnPush')) ?? baseConfig.ecr.scanOnPush,
     },
     general: {
       ...baseConfig.general,
       removalPolicy: app.node.tryGetContext('removalPolicy') || baseConfig.general.removalPolicy,
-      enableDetailedLogging: app.node.tryGetContext('enableDetailedLogging') ?? baseConfig.general.enableDetailedLogging,
-      enableContainerInsights: app.node.tryGetContext('enableContainerInsights') ?? baseConfig.general.enableContainerInsights,
+      enableDetailedLogging: parseContextBoolean(app.node.tryGetContext('enableDetailedLogging')) ?? baseConfig.general.enableDetailedLogging,
+      enableContainerInsights: parseContextBoolean(app.node.tryGetContext('enableContainerInsights')) ?? baseConfig.general.enableContainerInsights,
     },
     docker: {
       ...baseConfig.docker,
       takImageTag: app.node.tryGetContext('takImageTag') ?? baseConfig.docker?.takImageTag,
     },
   };
+}
+
+/**
+ * Parse context value to number, handling string inputs from CLI
+ */
+function parseContextNumber(value: any): number | undefined {
+  if (value === undefined || value === null) return undefined;
+  const parsed = typeof value === 'string' ? parseInt(value, 10) : value;
+  return isNaN(parsed) ? undefined : parsed;
+}
+
+/**
+ * Parse context value to boolean, handling string inputs from CLI
+ */
+function parseContextBoolean(value: any): boolean | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    return value.toLowerCase() === 'true';
+  }
+  return undefined;
 }

--- a/test/unit/utils/context-overrides.test.ts
+++ b/test/unit/utils/context-overrides.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Test suite for context overrides utility
+ */
+import { applyContextOverrides } from '../../../lib/utils/context-overrides';
+import { MOCK_CONFIGS } from '../../__fixtures__/mock-configs';
+
+describe('Context Overrides', () => {
+  test('should handle CLI context overrides with string values', () => {
+    // Simulate CLI context where all values are strings
+    const mockApp = {
+      node: {
+        tryGetContext: (key: string) => {
+          const cliValues: Record<string, string> = {
+            'backupRetentionDays': '7',
+            'instanceCount': '2',
+            'enablePerformanceInsights': 'false',
+            'deleteProtection': 'true',
+            'monitoringInterval': '60'
+          };
+          return cliValues[key];
+        }
+      }
+    } as any;
+
+    const result = applyContextOverrides(mockApp, MOCK_CONFIGS.DEV_TEST);
+    
+    expect(typeof result.database.backupRetentionDays).toBe('number');
+    expect(result.database.backupRetentionDays).toBe(7);
+    expect(typeof result.database.instanceCount).toBe('number');
+    expect(result.database.instanceCount).toBe(2);
+    expect(typeof result.database.enablePerformanceInsights).toBe('boolean');
+    expect(result.database.enablePerformanceInsights).toBe(false);
+    expect(typeof result.database.deleteProtection).toBe('boolean');
+    expect(result.database.deleteProtection).toBe(true);
+    expect(typeof result.database.monitoringInterval).toBe('number');
+    expect(result.database.monitoringInterval).toBe(60);
+  });
+});


### PR DESCRIPTION
# Fix: Type Conversion Error for CLI Context Parameters

## Problem
When passing context parameters via CLI (e.g., `--context backupRetentionDays=7`), CDK treats all values as strings. This caused a validation error in the database construct:

```
UnscopedValidationError: 7 must be a whole number of days.
```


The issue occurred because `Duration.days("7")` expects a number but received a string.

## Solution
Added helper functions to properly parse CLI context values:
- `parseContextNumber()` - Converts string numbers to integers
- `parseContextBoolean()` - Converts string booleans to actual booleans

Applied these parsers to all numeric and boolean context overrides in the configuration.

## Changes
- **lib/utils/context-overrides.ts**: Added type parsing for all context parameters
- Fixed database configuration parameters (backupRetentionDays, instanceCount, etc.)
- Fixed ECS configuration parameters (taskCpu, taskMemory, etc.)
- Fixed boolean parameters (enablePerformanceInsights, deleteProtection, etc.)

## Testing
- [x] CDK deployment now works with CLI context overrides
- [x] Numeric values properly converted from strings
- [x] Boolean values properly converted from strings
- [x] Maintains backward compatibility with existing configurations

## Impact
- Resolves deployment failures when using CLI context overrides
- Improves developer experience for parameterized deployments
- No breaking changes to existing functionality
