### PR TITLE
Fix ECS ListTasks Permission Error

### DIFF
--- a/lib/constructs/tak-server.ts
+++ b/lib/constructs/tak-server.ts
@@ -249,11 +249,14 @@ export class TakServer extends Construct {
       ]
     }));
 
-    // Add ECS ListTasks permission (requires cluster-level access)
+    // Add ECS ListTasks permission (requires cluster and container instance access)
     taskRole.addToPolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
       actions: ['ecs:ListTasks'],
-      resources: [`arn:aws:ecs:${Stack.of(this).region}:${Stack.of(this).account}:cluster/${props.infrastructure.ecsCluster.clusterName}`]
+      resources: [
+        `arn:aws:ecs:${Stack.of(this).region}:${Stack.of(this).account}:cluster/${props.infrastructure.ecsCluster.clusterName}`,
+        `arn:aws:ecs:${Stack.of(this).region}:${Stack.of(this).account}:container-instance/${props.infrastructure.ecsCluster.clusterName}/*`
+      ]
     }));
 
     // Add load balancer permissions for Certbot readiness checks


### PR DESCRIPTION
# Fix ECS ListTasks Permission Error

## Problem
TAK Server containers were failing with AccessDeniedException when calling the ecs:ListTasks operation on container instance resources.

## Solution
Extended the existing ecs:ListTasks IAM policy to include container instance resources alongside the existing cluster-level permissions.

## Changes
- lib/constructs/tak-server.ts: Added container-instance/* resource to the ListTasks policy statement

## Testing
- Deploy to dev environment and verify TAK Server starts without permission errors
- Confirm ECS service can successfully list tasks

## Impact
- Fixes runtime permission errors for TAK Server applications
- No breaking changes to existing functionality
