### PR TITLE
Fix Target Group Lookup Validation Error

### DIFF
--- a/docker-container/scripts/letsencrypt-request-cert.sh
+++ b/docker-container/scripts/letsencrypt-request-cert.sh
@@ -205,8 +205,7 @@ check_ecs_service_ready() {
         # Step 3: Find the HTTP target group (certbot target group)
         local target_group_arn
         if ! target_group_arn=$(aws elbv2 describe-target-groups \
-            --names "tak-*-certbot" \
-            --query 'TargetGroups[0].TargetGroupArn' \
+            --query 'TargetGroups[?contains(TargetGroupName, `certbot`)].TargetGroupArn | [0]' \
             --output text 2>/tmp/aws_error.log); then
             
             echo "Warning: Failed to find certbot target group"


### PR DESCRIPTION
## Fix Target Group Lookup Validation Error

**Problem:**
- Script was using invalid wildcard pattern `tak-*-certbot` in AWS CLI
- Caused repeated ValidationError: "Target group name can only contain alphanumeric characters or hyphens"

**Solution:**
- Replace `--names "tak-*-certbot"` with JMESPath query
- Use `--query 'TargetGroups[?contains(TargetGroupName, \`certbot\`)].TargetGroupArn | [0]'`

**Impact:**
- Eliminates AWS validation errors
- Maintains same functionality for finding certbot target group
