### PR TITLE
Increase TAK Server Health Check Start Period

### DIFF
--- a/lib/constructs/tak-server.ts
+++ b/lib/constructs/tak-server.ts
@@ -389,7 +389,7 @@ export class TakServer extends Construct {
         interval: Duration.seconds(30),
         timeout: Duration.seconds(30),
         retries: 3,
-        startPeriod: Duration.seconds(60)
+        startPeriod: Duration.seconds(180)
       },
       essential: true
     };


### PR DESCRIPTION
# Increase TAK Server Health Check Start Period

## Summary
Increases the ECS health check `startPeriod` from 60 seconds to 180 seconds to accommodate the slow startup time of the Java-based TAK Server.

## Problem
The TAK Server, being a Java application, has a relatively slow startup time that often exceeds the previous 60-second grace period. This was causing:
- Premature health check failures during container startup
- Unnecessary container restarts
- Service instability during deployments

## Solution
- Increased `startPeriod` to 180 seconds in the ECS health check configuration
- Provides adequate time for the TAK Server to fully initialize before health checks begin
- Maintains existing health check intervals and timeouts for ongoing monitoring

## Testing
- [ ] Verify container starts successfully without premature health check failures
- [ ] Confirm service stability during deployment
- [ ] Monitor CloudWatch logs for startup timing

## Impact
- Improved service reliability during startup
- Reduced false positive health check failures
- Better deployment success rate
