### PR TITLE
Fix: Enable S3 TAK Config for Dev-Test Demo Deployment

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -133,4 +133,4 @@ jobs:
         run: npm run cdk synth -- --context envType=dev-test --context stackName=${{ vars.STACK_NAME }}
 
       - name: Revert Demo to Dev-Test Profile
-        run: npm run cdk deploy -- --context envType=dev-test --context stackName=${{ vars.STACK_NAME }} --context letsEncryptMode=production --context usePreBuiltImages=true --context takImageTag=${{ needs.deploy-and-test.outputs.tak-tag }} --require-approval never
+        run: npm run cdk deploy -- --context envType=dev-test --context stackName=${{ vars.STACK_NAME }} --context letsEncryptMode=production --context usePreBuiltImages=true --context takImageTag=${{ needs.deploy-and-test.outputs.tak-tag }} --context useS3TAKServerConfigFile=true --require-approval never


### PR DESCRIPTION
## Fix: Enable S3 TAK Config for Dev-Test Demo Deployment

### Problem
Dev-test environment was configured with `useS3TAKServerConfigFile: false`, causing the TAK server to use default configuration instead of loading environment variables from S3.

### Solution
Added `--context useS3TAKServerConfigFile=true` to the dev-test deployment step in demo workflow.

### Impact
- TAK server will now properly load custom configuration from S3
- Environment variables from config file will be applied correctly
- Fixes CoreConfig.xml generation issues in demo environment
