### PR TITLE
Fix Duplicate ECR Images in Docker Builds

### DIFF
--- a/.github/workflows/demo-build.yml
+++ b/.github/workflows/demo-build.yml
@@ -124,6 +124,7 @@ jobs:
               -f docker/tak-server/Dockerfile.${BRANDING} \
               --build-arg TAK_VERSION=takserver-docker-${VERSION} \
               --build-arg ENVIRONMENT=${{ vars.STACK_NAME }} \
+              --no-cache \
               --rm \
               -t ${{ steps.tags.outputs.ecr-repo-uri }}:${{ steps.tags.outputs.tak-tag }} \
               .

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -122,6 +122,7 @@ jobs:
               -f docker/tak-server/Dockerfile.${BRANDING} \
               --build-arg TAK_VERSION=takserver-docker-${VERSION} \
               --build-arg ENVIRONMENT=${{ vars.STACK_NAME }} \
+              --no-cache \
               --rm \
               -t ${{ steps.tags.outputs.ecr-repo-uri }}:${{ steps.tags.outputs.tak-tag }} \
               .


### PR DESCRIPTION
## Fix Duplicate ECR Images in Docker Builds

### Problem
GitHub workflows were creating duplicate images in ECR - one tagged and one untagged with identical size, making the untagged image unusable.

### Solution
Added `--no-cache` flag to Docker build commands in both workflows:
- `.github/workflows/demo-build.yml`
- `.github/workflows/production-build.yml`

### Impact
- Eliminates duplicate untagged images in ECR
- Reduces ECR storage costs
- Cleaner image repository management

### Testing
- [ ] Verify single tagged image created in demo environment
- [ ] Verify single tagged image created in production environment
