### PR TITLE
Fix Duplicate Docker Images in ECR

### DIFF
--- a/.github/workflows/demo-build.yml
+++ b/.github/workflows/demo-build.yml
@@ -122,6 +122,7 @@ jobs:
             
             docker build \
               -f docker/tak-server/Dockerfile.${BRANDING} \
+              --platform linux/amd64 \
               --build-arg TAK_VERSION=takserver-docker-${VERSION} \
               --build-arg ENVIRONMENT=${{ vars.STACK_NAME }} \
               --no-cache \


### PR DESCRIPTION
## Fix Duplicate Docker Images in ECR

### Problem
ECR was showing duplicate images with the same tag but different SHA256 digests, created within seconds of each other during a single build process.

### Root Cause
GitHub Actions runners use Docker buildx by default, which can create multi-architecture manifests even when not explicitly requested, resulting in multiple manifest entries in ECR.

### Solution
- Added `--platform linux/amd64` to the `docker build` command to force single-platform builds
- Prevents buildx from creating both image manifests and manifest lists

### Changes
- Modified `.github/workflows/demo-build.yml` to include platform specification in Docker build step

### Testing
This should eliminate the duplicate image entries while maintaining the same functionality.
