### PR TITLE
Make CloudWatch logs exports configurable via context

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -28,7 +28,8 @@
         "enablePerformanceInsights": false,
         "monitoringInterval": 0,
         "backupRetentionDays": 7,
-        "deleteProtection": false
+        "deleteProtection": false,
+        "enableCloudWatchLogs": false
       },
       "ecs": {
         "taskCpu": 2048,
@@ -70,7 +71,8 @@
         "enablePerformanceInsights": true,
         "monitoringInterval": 60,
         "backupRetentionDays": 30,
-        "deleteProtection": true
+        "deleteProtection": true,
+        "enableCloudWatchLogs": false
       },
       "ecs": {
         "taskCpu": 4096,

--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -153,6 +153,7 @@ Use CDK's built-in `--context` flag with **flat parameter names** to override an
 | `monitoringInterval` | Enhanced monitoring interval (seconds) | `0` | `60` |
 | `backupRetentionDays` | Backup retention period (days) | `7` | `30` |
 | `deleteProtection` | Enable deletion protection | `false` | `true` |
+| `enableCloudWatchLogs` | Enable CloudWatch logs exports | `false` | `false` |
 
 ### **ECS Configuration**
 | Parameter | Description | dev-test | prod |
@@ -170,6 +171,7 @@ Use CDK's built-in `--context` flag with **flat parameter names** to override an
 | `servicename` | Service name for TAK Server | `ops` | `ops` |
 | `branding` | Docker image branding variant | `tak-nz` | `tak-nz` |
 | `version` | TAK Server version | `5.4-RELEASE-19` | `5.4-RELEASE-19` |
+| `buildRevision` | Build revision number | `0` | `0` |
 | `useS3TAKServerConfigFile` | Use S3 configuration file | `false` | `true` |
 | `letsEncryptMode` | Let's Encrypt certificate mode | `staging` | `production` |
 | `letsEncryptEmail` | Let's Encrypt email address | `admin@tak.nz` | `admin@tak.nz` |
@@ -365,6 +367,7 @@ npm run deploy:dev -- --context tak-region="us-east-1"
 | `monitoringInterval` | number | Enhanced monitoring interval (seconds) | `0`, `15`, `30`, `60` |
 | `backupRetentionDays` | number | Backup retention period (days) | `1-35` |
 | `deleteProtection` | boolean | Enable deletion protection | `true`, `false` |
+| `enableCloudWatchLogs` | boolean | Enable CloudWatch logs exports | `true`, `false` |
 
 ### **ECS Configuration**
 | Parameter | Type | Description | Valid Values |
@@ -382,6 +385,7 @@ npm run deploy:dev -- --context tak-region="us-east-1"
 | `servicename` | string | TAK Service name | Any valid hostname |
 | `branding` | string | Docker image branding | `tak-nz`, `generic` |
 | `version` | string | TAK Server version | `5.4-RELEASE-19`, etc. |
+| `buildRevision` | number | Build revision number | `0`, `1`, `2`, etc. |
 | `useS3TAKServerConfigFile` | boolean | Use S3 configuration file | `true`, `false` |
 | `letsEncryptMode` | string | Let's Encrypt mode | `staging`, `production` |
 | `letsEncryptEmail` | string | Let's Encrypt email | Valid email address |

--- a/lib/constructs/database.ts
+++ b/lib/constructs/database.ts
@@ -168,7 +168,7 @@ export class Database extends Construct {
         },
         deletionProtection: props.contextConfig.database.deleteProtection,
         removalPolicy: removalPolicy,
-        cloudwatchLogsExports: ['postgresql'],
+        cloudwatchLogsExports: props.contextConfig.database.enableCloudWatchLogs ? ['postgresql'] : undefined,
         cloudwatchLogsRetention: props.contextConfig.general.enableDetailedLogging ? 
           logs.RetentionDays.ONE_MONTH : 
           logs.RetentionDays.ONE_WEEK,
@@ -221,7 +221,7 @@ export class Database extends Construct {
         },
         deletionProtection: props.contextConfig.database.deleteProtection,
         removalPolicy: removalPolicy,
-        cloudwatchLogsExports: ['postgresql'],
+        cloudwatchLogsExports: props.contextConfig.database.enableCloudWatchLogs ? ['postgresql'] : undefined,
         cloudwatchLogsRetention: props.contextConfig.general.enableDetailedLogging ? 
           logs.RetentionDays.ONE_MONTH : 
           logs.RetentionDays.ONE_WEEK,

--- a/lib/stack-config.ts
+++ b/lib/stack-config.ts
@@ -19,6 +19,7 @@ export interface ContextEnvironmentConfig {
     monitoringInterval: number;
     backupRetentionDays: number;
     deleteProtection: boolean;
+    enableCloudWatchLogs?: boolean;
   };
   ecs: {
     taskCpu: number;
@@ -32,6 +33,7 @@ export interface ContextEnvironmentConfig {
     servicename: string;
     branding: string;
     version: string;
+    buildRevision?: number;
     useS3TAKServerConfigFile: boolean;
     letsEncryptMode?: string;
     letsEncryptEmail?: string;

--- a/lib/utils/context-overrides.ts
+++ b/lib/utils/context-overrides.ts
@@ -28,6 +28,7 @@ export function applyContextOverrides(
       monitoringInterval: parseContextNumber(app.node.tryGetContext('monitoringInterval')) ?? baseConfig.database.monitoringInterval,
       backupRetentionDays: parseContextNumber(app.node.tryGetContext('backupRetentionDays')) ?? baseConfig.database.backupRetentionDays,
       deleteProtection: parseContextBoolean(app.node.tryGetContext('deleteProtection')) ?? baseConfig.database.deleteProtection,
+      enableCloudWatchLogs: parseContextBoolean(app.node.tryGetContext('enableCloudWatchLogs')) ?? baseConfig.database.enableCloudWatchLogs,
     },
     ecs: {
       ...baseConfig.ecs,
@@ -39,10 +40,11 @@ export function applyContextOverrides(
     },
     takserver: {
       ...baseConfig.takserver,
-      hostname: app.node.tryGetContext('takServerHostname') ?? baseConfig.takserver.hostname,
-      servicename: app.node.tryGetContext('takServerServicename') ?? baseConfig.takserver.servicename,
+      hostname: app.node.tryGetContext('hostname') ?? baseConfig.takserver.hostname,
+      servicename: app.node.tryGetContext('servicename') ?? baseConfig.takserver.servicename,
       branding: app.node.tryGetContext('branding') ?? baseConfig.takserver.branding,
-      version: app.node.tryGetContext('takServerVersion') ?? baseConfig.takserver.version,
+      version: app.node.tryGetContext('version') ?? baseConfig.takserver.version,
+      buildRevision: parseContextNumber(app.node.tryGetContext('buildRevision')) ?? baseConfig.takserver.buildRevision,
       useS3TAKServerConfigFile: parseContextBoolean(app.node.tryGetContext('useS3TAKServerConfigFile')) ?? baseConfig.takserver.useS3TAKServerConfigFile,
       letsEncryptMode: app.node.tryGetContext('letsEncryptMode') ?? baseConfig.takserver.letsEncryptMode,
       letsEncryptEmail: app.node.tryGetContext('letsEncryptEmail') ?? baseConfig.takserver.letsEncryptEmail,


### PR DESCRIPTION
This PR adds the ability to enable/disable CloudWatch logs exports for the RDS database via context configuration.

## Changes
- Add `enableCloudWatchLogs` parameter to database config (default: false for both dev-test and prod)
- Make CloudWatch logs exports conditional based on this parameter
- Fix parameter name mismatches in context-overrides.ts (hostname, servicename, version)
- Add missing buildRevision parameter to context-overrides.ts
- Update documentation in PARAMETERS.md

## Usage
To enable CloudWatch logs exports:
```bash
npm run deploy:dev -- --context enableCloudWatchLogs=true
