### PR TITLE
Fix Bash Syntax Error in GitHub Actions Workflows

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -50,7 +50,8 @@ jobs:
       - name: Validate Change Set
         run: |
           # Check if override is requested
-          if [[ "${{ github.event.head_commit.message }}" == *"[force-deploy]"* ]]; then
+          COMMIT_MSG="${{ github.event.head_commit.message }}"
+          if [[ "$COMMIT_MSG" == *"[force-deploy]"* ]]; then
             echo "🚨 Force deploy detected - skipping change set validation"
           else
             ./scripts/github/validate-changeset.sh TAK-${{ vars.DEMO_STACK_NAME }}-TakInfra

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -58,7 +58,8 @@ jobs:
       - name: Validate Production Change Set
         run: |
           # Check if override is requested
-          if [[ "${{ github.event.head_commit.message }}" == *"[force-deploy]"* ]]; then
+          COMMIT_MSG="${{ github.event.head_commit.message }}"
+          if [[ "$COMMIT_MSG" == *"[force-deploy]"* ]]; then
             echo "🚨 Force deploy detected - skipping change set validation"
           else
             ./scripts/github/validate-changeset.sh TAK-${{ vars.PROD_STACK_NAME }}-TakInfra


### PR DESCRIPTION
## Problem
GitHub Actions workflows were failing with "conditional binary operator expected" error when commit messages contained special characters or multi-line content. This occurred when checking for `[force-deploy]` flag in commit messages.

## Root Cause
The workflows were directly using `${{ github.event.head_commit.message }}` in bash conditionals, causing syntax errors when commit messages contained:
- Quotes and special characters
- Multi-line content
- Parentheses and asterisks

## Solution
Store the commit message in a variable before using it in conditionals:

**Before:**
```bash
if [[ "${{ github.event.head_commit.message }}" == *"[force-deploy]"* ]]; then
```

**After:**
```bash
COMMIT_MSG="${{ github.event.head_commit.message }}"
if [[ "$COMMIT_MSG" == *"[force-deploy]"* ]]; then
```

## Files Changed
- `.github/workflows/production-deploy.yml`
- `.github/workflows/demo-deploy.yml`

## Testing
This fix prevents bash from interpreting special characters in commit messages as shell syntax, resolving the deployment pipeline failures.