### PR TITLE
Optimize Retention Config Backup with Rsync Update Mode

### DIFF
--- a/docker-container/scripts/start-tak.sh
+++ b/docker-container/scripts/start-tak.sh
@@ -298,8 +298,8 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 # Clean up duplicate certificates every 15 minutes
 */15 * * * * root /opt/tak/scripts/revoke-duplicate-certs.sh >> /var/log/tak-cert-cleanup.log 2>&1
 
-# Backup retention config every 10 minutes
-*/5 * * * * root mkdir -p /opt/tak/persistent-config/retention && cp -r /opt/tak/conf/retention/* /opt/tak/persistent-config/retention/ 2>/dev/null || true
+# Backup retention config every 5 minutes (only if newer)
+*/5 * * * * root mkdir -p /opt/tak/persistent-config/retention && rsync -au /opt/tak/conf/retention/ /opt/tak/persistent-config/retention/ 2>/dev/null || true
 EOF
 
 # Start cron in background


### PR DESCRIPTION
## Summary
Optimize the retention configuration backup process by using `rsync -au` instead of `cp -r` to only copy files when the source is newer than the destination.

## Changes
- **Cron Job Optimization**: Replace `cp -r` with `rsync -au` in retention config backup cron job
- **Reduced I/O**: Only copy files when they have actually been modified
- **Preserve Metadata**: Archive mode preserves file permissions and timestamps

## Technical Details
- `rsync -au` flags:
  - `-a`: Archive mode (preserves permissions, timestamps, ownership)
  - `-u`: Update mode (skip files that are newer on the destination)
- Backup frequency remains at 5 minutes
- Error handling preserved with `2>/dev/null || true`

## Benefits
- **Performance**: Reduces unnecessary file operations when retention config hasn't changed
- **Efficiency**: Only transfers modified files, saving disk I/O and CPU cycles
- **Reliability**: Preserves file metadata and handles edge cases gracefully
- **Scalability**: Better performance as retention config grows in size

## Testing
- [X] Verify backup only occurs when retention files are modified
- [X] Confirm unchanged files are skipped during backup
- [X] Test file permissions and timestamps are preserved
- [X] Validate error handling when source directory is empty
