### PR TITLE
fix(security): bump form-data to 4.0.6 in webtak-oidc-setup

### DIFF
--- a/src/webtak-oidc-setup/package-lock.json
+++ b/src/webtak-oidc-setup/package-lock.json
@@ -11,7 +11,7 @@
         "@aws-sdk/client-secrets-manager": "^3.1013.0",
         "axios": "^1.16.0",
         "dotenv": "^16.4.5",
-        "form-data": "^4.0.1"
+        "form-data": "^4.0.6"
       }
     },
     "node_modules/@aws-crypto/sha256-browser": {
@@ -1429,16 +1429,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -1530,9 +1530,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"

--- a/src/webtak-oidc-setup/package.json
+++ b/src/webtak-oidc-setup/package.json
@@ -7,7 +7,7 @@
     "@aws-sdk/client-secrets-manager": "^3.1013.0",
     "axios": "^1.16.0",
     "dotenv": "^16.4.5",
-    "form-data": "^4.0.1"
+    "form-data": "^4.0.6"
   },
   "overrides": {
     "fast-xml-parser": ">=5.7.0",


### PR DESCRIPTION
**Description:**

Resolves Dependabot alert #65 — GHSA-hmw2-7cc7-3qxx.

`form-data` ≥4.0.0 <4.0.6 allowed CRLF injection (CWE-93) via unescaped `\r`, `\n`, and `"` in multipart field names and filenames. An attacker controlling a field name or filename could inject arbitrary headers or smuggle additional multipart parts into forwarded requests.

**Changes**

- `form-data` direct dep bumped from `^4.0.1` to `^4.0.6`
- Transitive `form-data` pulled in via `axios@1.16.1` deduplicates to `4.0.6`

Both the root `package.json` and `src/webtak-oidc-setup/package.json` were audited — this is the only package requiring a fix.

**Testing**

`npm audit` reports 0 vulnerabilities in both packages.