### PR TITLE
feat: enable WebTAK for Dev-Test and Prod environments

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -63,7 +63,7 @@
         "enableContainerInsights": false
       },
       "webtak": {
-        "enabled": false,
+        "enabled": true,
         "enableOidc": true,
         "providerName": "TAK-WebTAK",
         "applicationName": "WebTAK",
@@ -124,7 +124,7 @@
         "enableContainerInsights": true
       },
       "webtak": {
-        "enabled": false,
+        "enabled": true,
         "enableOidc": true,
         "providerName": "TAK-WebTAK",
         "applicationName": "WebTAK",


### PR DESCRIPTION
Sets `webtak.enabled` to `true` in both the Dev-Test and Prod environment configurations in `cdk.json`. Previously disabled in both environments.

**Changes**

- `cdk.json` — Dev-Test: `webtak.enabled` `false` → `true`
- `cdk.json` — Prod: `webtak.enabled` `false` → `true`

All other WebTAK settings (`enableOidc`, `providerName`, `applicationName`, etc.) are unchanged.