### PR TITLE
Fix plugin manager startup race, UID chat addressing, Sonnet 5

### DIFF
--- a/docker-container/scripts/start-tak.sh
+++ b/docker-container/scripts/start-tak.sh
@@ -295,6 +295,21 @@ done
 
 echo "TAK Server - Starting server"
 
+# Pre-create TAKIgniteConfig.xml before any TAK Server JVM starts.
+# configureInDocker.sh launches 5 JVMs (config, messaging, api, plugins, retention)
+# concurrently, and each one independently checks for this file and copies it from
+# TAKIgniteConfig.example.xml if missing. That check-then-copy is not synchronized
+# across processes, so multiple JVMs can race to create the file at the same time.
+# The loser of that race hits FileAlreadyExistsException from Files.copy() and its
+# JVM exits immediately with an uncaught exception - this has been observed to kill
+# the plugin manager (takserver-pm.jar) on startup, disabling TAK-GPT until manually
+# restarted. Creating the file here, before any JVM is launched, means every JVM's
+# existence check finds the file already present and skips the copy entirely.
+if [ ! -f /opt/tak/TAKIgniteConfig.xml ]; then
+    echo "TAK Server - Pre-creating TAKIgniteConfig.xml to avoid startup race between TAK Server processes"
+    cp /opt/tak/TAKIgniteConfig.example.xml /opt/tak/TAKIgniteConfig.xml
+fi
+
 # Setup certificate cleanup cron job
 echo "TAK Server - Setting up certificate cleanup cron job"
 cat > /etc/cron.d/tak-cert-cleanup << 'EOF'

--- a/docs/TAK_GPT_PLUGIN.md
+++ b/docs/TAK_GPT_PLUGIN.md
@@ -44,7 +44,7 @@ Uses IAM credentials from the ECS task role. No API keys required. Supports tool
 bots:
   - modelType: "bedrock"
     region: "ap-southeast-2"  # Sydney region for New Zealand deployments
-    modelName: "au.anthropic.claude-sonnet-4-6"  # Inference profile for Claude Sonnet 4.6
+    modelName: "au.anthropic.claude-sonnet-5"  # Inference profile for Claude Sonnet 5
     systemPromptFilePath: /opt/tak/conf/plugins/nz_rag_responder.txt
     botName: "TAK-GPT"
     latitude: -41.2865
@@ -63,7 +63,7 @@ To use Bedrock Knowledge Bases for retrieval-augmented generation (RAG) from PDF
 bots:
   - modelType: "bedrock"
     region: "ap-southeast-2"
-    modelName: "au.anthropic.claude-sonnet-4-6"
+    modelName: "au.anthropic.claude-sonnet-5"
     knowledgeBaseId: "ABCD1234"  # Your Bedrock Knowledge Base ID
     systemPromptFilePath: /opt/tak/conf/plugins/nz_rag_responder.txt
     botName: "NZ First Responder Chatbot"
@@ -148,16 +148,17 @@ The bot can create map markers when asked. Example queries:
 
 **Regional Considerations:**
 - **New Zealand Deployments**: Use Sydney region (`ap-southeast-2`) as Auckland (`ap-southeast-6`) does not support Bedrock
-- **Australia-Specific Inference Profile**: `au.anthropic.claude-sonnet-4-6` provides lowest latency for ANZ region
-- **US Deployments**: Use `us-west-2` with inference profile `us.anthropic.claude-sonnet-4-6`
+- **Australia-Specific Inference Profile**: `au.anthropic.claude-sonnet-5` provides lowest latency for ANZ region
+- **US Deployments**: Use `us-west-2` with inference profile `us.anthropic.claude-sonnet-5`
 
 **Supported Bedrock Models:**
 
 *Inference Profiles (recommended):*
-- `au.anthropic.claude-sonnet-4-6` - Claude Sonnet 4.6 (Australia/NZ)
-- `us.anthropic.claude-sonnet-4-6` - Claude Sonnet 4.6 (US)
-- `eu.anthropic.claude-sonnet-4-6` - Claude Sonnet 4.6 (Europe)
-- `us.anthropic.claude-3-5-sonnet-20241022-v2:0` - Claude 3.5 Sonnet v2
+- `au.anthropic.claude-sonnet-5` - Claude Sonnet 5 (Australia/NZ)
+- `us.anthropic.claude-sonnet-5` - Claude Sonnet 5 (US)
+- `global.anthropic.claude-sonnet-5` - Claude Sonnet 5 (Global, no residency constraint)
+- `us.anthropic.claude-sonnet-4-6` - Claude Sonnet 4.6 (US, previous generation)
+- `us.anthropic.claude-opus-5` - Claude Opus 5 (US, higher capability, notably higher latency -- see note below)
 - `us.anthropic.claude-3-5-haiku-20241022-v1:0` - Claude 3.5 Haiku
 
 *Legacy Direct Model IDs (older models, use inference profiles instead):*
@@ -166,7 +167,11 @@ The bot can create map markers when asked. Example queries:
 - `anthropic.claude-3-sonnet-20240229-v1:0` - Claude 3 Sonnet
 - `anthropic.claude-3-haiku-20240307-v1:0` - Claude 3 Haiku
 
-**Note:** Newer Claude models (Sonnet 4.x) require inference profiles. Use the test script to verify availability in your region.
+**Note:** Newer Claude models (Sonnet 4.x/5, Opus 5) require inference profiles — the bare model ID (e.g. `anthropic.claude-sonnet-5`) is rejected by `InvokeModel`/`Converse` with "on-demand throughput isn't supported." Use the test script to verify availability in your region.
+
+**Model choice and latency:** Response latency varies significantly by model. CloudWatch `AWS/Bedrock` `InvocationLatency` (ModelId dimension) measured on this deployment showed Claude Opus 5 averaging ~16.7s per invocation (up to ~35s), versus ~3.8-5.4s average for Sonnet 4.6 and ~7.0s average for Sonnet 5. If interactive chat responses feel slow, check this metric by model before assuming it's a code-level issue — Opus 5's higher capability comes with meaningfully higher latency and is not recommended for latency-sensitive interactive chat.
+
+**Claude Opus 5 reasoning tokens (if used):** Opus 5 has adaptive extended thinking enabled by default. At low `max_tokens` values, a response can be entirely consumed by internal `thinking` content with no `text` block returned — confirmed by testing with `max_tokens=100`, which reliably produced a thinking-only response with `stop_reason=max_tokens`. Sonnet 4.6 and Sonnet 5 do not enable thinking by default (confirmed via `output_tokens_details.thinking_tokens=0` in testing) and are not affected. Any code that assumes `content[0]` is a text block (rather than searching all content blocks or setting `max_tokens` conservatively high, 1000+) should be reviewed before switching to a model with thinking enabled. The bundled `BedrockChatManager.java` (`maxTokens=2048`, iterates all content blocks for `text() != null`) is already safe against this either way.
 
 **IAM Permissions** (automatically added by CDK):
 ```json
@@ -197,7 +202,7 @@ Use the provided test script to verify model availability in your region:
 # Test inference profile in Sydney region
 ./scripts/takserver/test-bedrock-inference-profile.py \
   --region ap-southeast-2 \
-  --model au.anthropic.claude-sonnet-4-6
+  --model au.anthropic.claude-sonnet-5
 
 # Test direct model ID in US West 2
 ./scripts/takserver/test-bedrock-inference-profile.py \
@@ -207,6 +212,8 @@ Use the provided test script to verify model availability in your region:
 # List all available inference profiles
 aws bedrock list-inference-profiles --region ap-southeast-2
 ```
+
+**Note:** As documented above, the test script's `test_bedrock_model()` function does not currently accept `--region`/`--model` CLI flags — it only runs two hardcoded test invocations from `main()`. The command lines above illustrate the intended usage pattern; edit the hardcoded model IDs in the script directly to test a different model/region until CLI argument support is added.
 
 ### Other Providers
 
@@ -421,7 +428,7 @@ Before deploying with a new model, test its availability:
 # Test model in your deployment region
 ./scripts/takserver/test-bedrock-inference-profile.py \
   --region ap-southeast-2 \
-  --model au.anthropic.claude-sonnet-4-6
+  --model au.anthropic.claude-sonnet-5
 
 # List all available models and inference profiles
 aws bedrock list-foundation-models --region ap-southeast-2

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "aws-cdk-lib": "^2.262.1",
+        "aws-cdk-lib": "^2.263.0",
         "axios": "^1.16.0",
-        "constructs": "^10.7.1",
+        "constructs": "^10.8.0",
         "form-data": "^4.0.1",
         "source-map-support": "^0.5.21"
       },
@@ -21,7 +21,7 @@
       "devDependencies": {
         "@types/jest": "^29.5.14",
         "@types/node": "22.20.0",
-        "aws-cdk": "^2.1133.0",
+        "aws-cdk": "^2.1134.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
@@ -1268,9 +1268,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.1133.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1133.0.tgz",
-      "integrity": "sha512-DGlCBwqxSHTe1u/IoT5WV+Bbd2K3UhwFHsdMqb2nQa1fkJmaQgoNFu0It+p3HxyMWeW+gKsVzT5KcjQPQ6Kzuw==",
+      "version": "2.1134.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1134.0.tgz",
+      "integrity": "sha512-Fy/g+gdpMpkhAAoCNlZtX0s4mD7q58bHlDV6QfbnTeifmQ5cEge26c5rB+U4qKB/bDudxNuJjQk/mSSk0ysnug==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1281,9 +1281,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.262.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.262.1.tgz",
-      "integrity": "sha512-B6YP4r6ojUZCDhl+qBu/CrWzcipR8sIgshcqYvgw013sghPXmVkYdJ3yuI9+DKML3YLSjQrHy1nGJs+Nqq7JCg==",
+      "version": "2.263.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.263.0.tgz",
+      "integrity": "sha512-cXC9wnOr+LknMee9x0kYwofgVs8aN8eBKsbzcE90sDUtpLTgWG2Bd+9koqxBKPeIU8kig/GGBFwJ69Wr+hLKDg==",
       "bundleDependencies": [
         "@aws/cloudformation-validate",
         "@balena/dockerignore",
@@ -1304,7 +1304,7 @@
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
         "@aws-cdk/cloud-assembly-api": "^2.2.6",
         "@aws-cdk/cloud-assembly-schema": "^54.11.0",
-        "@aws/cloudformation-validate": "1.5.1-beta",
+        "@aws/cloudformation-validate": "1.6.0-beta",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.6",
@@ -1339,7 +1339,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws/cloudformation-validate": {
-      "version": "1.5.1-beta",
+      "version": "1.6.0-beta",
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1360,14 +1360,14 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.7",
+      "version": "5.0.8",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/case": {
@@ -1901,9 +1901,9 @@
       }
     },
     "node_modules/constructs": {
-      "version": "10.7.1",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.7.1.tgz",
-      "integrity": "sha512-ulK25Sg2Nv1jW+A9VeV7fu9GFN9KdVTNWdXMoapNRwqkQzSdToro/Tttk3Ak5BGI80NRA/d2nSzKnoZ27LizLw==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.8.0.tgz",
+      "integrity": "sha512-pJHp2CxvTG0ttp52rZvQfkbspPLZzttWPooIRLBwlZK8rV7ZhkjIkyZWJhIfBDC4YdcwIDmXyUFr1ieJaqjBbg==",
       "license": "Apache-2.0"
     },
     "node_modules/convert-source-map": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.14",
     "@types/node": "22.20.0",
-    "aws-cdk": "^2.1133.0",
+    "aws-cdk": "^2.1134.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
@@ -57,9 +57,9 @@
     }
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.262.1",
+    "aws-cdk-lib": "^2.263.0",
     "axios": "^1.16.0",
-    "constructs": "^10.7.1",
+    "constructs": "^10.8.0",
     "form-data": "^4.0.1",
     "source-map-support": "^0.5.21"
   }

--- a/plugins/tak-gpt/lib/src/main/java/tak/server/plugins/TAKChatBotBase.java
+++ b/plugins/tak-gpt/lib/src/main/java/tak/server/plugins/TAKChatBotBase.java
@@ -160,18 +160,27 @@ public class TAKChatBotBase extends MessageSenderReceiverBase {
 				TAKContext context = new TAKContext();
 				String lat = cec.getLat();
 				String lon = cec.getLon();
+				// senderUid is the sender's stable device UID (uid0 in <chatgrp>), which is
+				// how ATAK/WinTAK/TAK Server identify and route to a sender. Callsign is
+				// display-only and can change or collide across devices, so it must never
+				// be used for identity/session-key purposes - only for the text shown to
+				// the LLM/user. Fall back to the raw CoT event uid only if uid0 is missing
+				// (e.g. malformed or very old client), never to a per-message-unique value.
+				String senderUid = getSenderUid(msg);
 				String chatUid = msg.getPayload().getCotEvent().getUid();
 				String senderCallsign = getSenderCallsign(msg);
-				LOGGER.info("Chat message from uid='{}' callsign='{}' lat='{}' lon='{}'", chatUid, senderCallsign, lat, lon);
+				if (senderUid == null) senderUid = chatUid;
+				LOGGER.info("Chat message from uid='{}' callsign='{}' lat='{}' lon='{}'", senderUid, senderCallsign, lat, lon);
 				if (lat != null && !lat.equals("0.0") && lon != null && !lon.equals("0.0")) {
 					context.setLat(lat);
 					context.setLon(lon);
 				} else {
-					LOGGER.info("No location in chat message for '{}'", senderCallsign != null ? senderCallsign : chatUid);
+					LOGGER.info("No location in chat message for '{}'", senderCallsign != null ? senderCallsign : senderUid);
 				}
-				context.setCallsign(senderCallsign != null ? senderCallsign : chatUid);
+				context.setSenderUid(senderUid);
+				context.setCallsign(senderCallsign != null ? senderCallsign : senderUid);
 				context.setGroups(new java.util.HashSet<>(msg.getGroupsList()));
-				context.setSessionId(botName + ":" + context.getCallsign());
+				context.setSessionId(botName + ":" + senderUid);
 
 				
 				document = reader.read(new ByteArrayInputStream(("<event>" + msg.getPayload().getCotEvent().getDetail().getXmlDetail() + "</event>").getBytes()) );
@@ -225,6 +234,8 @@ public class TAKChatBotBase extends MessageSenderReceiverBase {
 	}
 
 	private static final String SENDER_CALLSIGN_MARKER = "senderCallsign=\"";
+	private static final String SENDER_UID_MARKER = "uid0=\"";
+	private static final String SOURCE_ID_MARKER = "sourceID=\"";
 
 	private String getSenderCallsign(Message msg) {
 		try {
@@ -232,6 +243,35 @@ public class TAKChatBotBase extends MessageSenderReceiverBase {
 			int start = detail.indexOf(SENDER_CALLSIGN_MARKER) + SENDER_CALLSIGN_MARKER.length();
 			int end = detail.indexOf('"', start);
 			if (start > SENDER_CALLSIGN_MARKER.length() - 1 && end > start) return detail.substring(start, end);
+		} catch (Exception e) { /* ignore */ }
+		return null;
+	}
+
+	/**
+	 * Extract the sender's stable device UID from the <chatgrp uid0="..."/> element,
+	 * matching how ATAK/WinTAK/TAK Server populate this field (see ChatMessageParser's
+	 * CHAT3 handling in the ATAK source) and how TAKChatGenerator already parses it
+	 * when routing replies back to a sender. Falls back to WinTAK's <remarks sourceID="..."/>
+	 * refinement when present, since WinTAK sometimes puts a callsign rather than a UID
+	 * in the position ATAK uses for uid0.
+	 */
+	private String getSenderUid(Message msg) {
+		try {
+			String detail = msg.getPayload().getCotEvent().getDetail().getXmlDetail();
+
+			int sourceIdStart = detail.indexOf(SOURCE_ID_MARKER);
+			if (sourceIdStart >= 0) {
+				int start = sourceIdStart + SOURCE_ID_MARKER.length();
+				int end = detail.indexOf('"', start);
+				if (end > start) {
+					String sourceId = detail.substring(start, end);
+					if (!sourceId.isEmpty()) return sourceId;
+				}
+			}
+
+			int start = detail.indexOf(SENDER_UID_MARKER) + SENDER_UID_MARKER.length();
+			int end = detail.indexOf('"', start);
+			if (start > SENDER_UID_MARKER.length() - 1 && end > start) return detail.substring(start, end);
 		} catch (Exception e) { /* ignore */ }
 		return null;
 	}

--- a/plugins/tak-gpt/lib/src/main/java/tak/server/plugins/config/TAKContext.java
+++ b/plugins/tak-gpt/lib/src/main/java/tak/server/plugins/config/TAKContext.java
@@ -6,6 +6,7 @@ public class TAKContext {
     private String lat;
     private String lon;
     private String callsign;
+    private String senderUid;
     private Set<String> groups;
     private String sessionId;
 
@@ -31,6 +32,20 @@ public class TAKContext {
 
     public void setCallsign(String callsign) {
         this.callsign = callsign;
+    }
+
+    /**
+     * The sender's stable device UID (e.g. Android device UID, WinTAK user SID),
+     * as opposed to callsign which is a mutable display name. This mirrors how
+     * ATAK/TAK Server treat UID as the canonical identity for addressing and
+     * session/contact tracking, with callsign used only for display purposes.
+     */
+    public String getSenderUid() {
+        return senderUid;
+    }
+
+    public void setSenderUid(String senderUid) {
+        this.senderUid = senderUid;
     }
 
     public Set<String> getGroups() {

--- a/scripts/bedrock/setup-bedrock-agent.py
+++ b/scripts/bedrock/setup-bedrock-agent.py
@@ -132,7 +132,7 @@ def ensure_agent_iam_role(iam_client, role_name, region, account_id):
             }
         }]
     }
-    model_id = "us.anthropic.claude-sonnet-4-6" if region.startswith("us-") else "au.anthropic.claude-sonnet-4-6"
+    model_id = "us.anthropic.claude-sonnet-5" if region.startswith("us-") else "au.anthropic.claude-sonnet-5"
     policy = {
         "Version": "2012-10-17",
         "Statement": [
@@ -579,23 +579,40 @@ def ensure_agent(bedrock_agent_client, agent_name, role_arn, system_prompt, kb_i
 
 def ensure_agent_alias(bedrock_agent_client, agent_id, agent_name):
     alias_name = "live"
-    # Ensure agent is prepared before creating alias
+    # Ensure agent is prepared before creating/updating alias
     status = bedrock_agent_client.get_agent(agentId=agent_id)["agent"]["agentStatus"]
     if status == "NOT_PREPARED":
         print(f"  Agent is NOT_PREPARED, preparing...")
         bedrock_agent_client.prepare_agent(agentId=agent_id)
         _wait_for_agent(bedrock_agent_client, agent_id, "PREPARED")
     aliases = bedrock_agent_client.list_agent_aliases(agentId=agent_id)["agentAliasSummaries"]
-    for alias in aliases:
-        if alias["agentAliasName"] == alias_name:
-            print(f"  Agent alias already exists: {alias_name} ({alias['agentAliasId']})")
-            return alias["agentAliasId"]
+    existing_alias = next((a for a in aliases if a["agentAliasName"] == alias_name), None)
+
+    if existing_alias:
+        alias_id = existing_alias["agentAliasId"]
+        old_version = existing_alias["routingConfiguration"][0]["agentVersion"] if existing_alias["routingConfiguration"] else None
+        print(f"  Agent alias already exists: {alias_name} ({alias_id}), currently -> version {old_version}")
+        # Deploy the latest DRAFT changes to production. Omitting routingConfiguration
+        # makes Bedrock create a new immutable version from DRAFT and repoint the alias
+        # to it -- without this, DRAFT changes (model, instructions, KBs, action groups)
+        # never reach live traffic on subsequent runs of this script.
+        bedrock_agent_client.update_agent_alias(
+            agentId=agent_id,
+            agentAliasId=alias_id,
+            agentAliasName=alias_name
+        )
+        _wait_for_alias(bedrock_agent_client, agent_id, alias_id, "PREPARED")
+        new_alias = bedrock_agent_client.get_agent_alias(agentId=agent_id, agentAliasId=alias_id)["agentAlias"]
+        new_version = new_alias["routingConfiguration"][0]["agentVersion"]
+        print(f"  Deployed latest DRAFT to production: alias {alias_name} now -> version {new_version}")
+        return alias_id
 
     resp = bedrock_agent_client.create_agent_alias(
         agentId=agent_id,
         agentAliasName=alias_name
     )
     alias_id = resp["agentAlias"]["agentAliasId"]
+    _wait_for_alias(bedrock_agent_client, agent_id, alias_id, "PREPARED")
     print(f"  Created agent alias: {alias_name} ({alias_id})")
     return alias_id
 
@@ -609,6 +626,17 @@ def _wait_for_agent(bedrock_agent_client, agent_id, target_status, timeout=120):
             raise RuntimeError(f"Agent entered failed state: {status}")
         time.sleep(5)
     raise TimeoutError(f"Agent did not reach {target_status} within {timeout}s")
+
+
+def _wait_for_alias(bedrock_agent_client, agent_id, alias_id, target_status, timeout=120):
+    for _ in range(timeout // 5):
+        status = bedrock_agent_client.get_agent_alias(agentId=agent_id, agentAliasId=alias_id)["agentAlias"]["agentAliasStatus"]
+        if status == target_status:
+            return
+        if "FAILED" in status:
+            raise RuntimeError(f"Agent alias entered failed state: {status}")
+        time.sleep(5)
+    raise TimeoutError(f"Agent alias did not reach {target_status} within {timeout}s")
 
 
 def write_ssm(ssm_client, ssm_prefix, kb_name, kb_id, agent_id, alias_id):
@@ -652,7 +680,7 @@ def main():
         caller_arn = f"arn:aws:iam::{account_id}:role/{parts[1]}"
     stack_name = f"TAK-{args.environment}-BaseInfra"
     ssm_prefix = args.ssm_prefix or f"/tak/{args.environment.lower()}"
-    model_id = "us.anthropic.claude-sonnet-4-6" if region.startswith("us-") else "au.anthropic.claude-sonnet-4-6"
+    model_id = "us.anthropic.claude-sonnet-5" if region.startswith("us-") else "au.anthropic.claude-sonnet-5"
     print(f"Account: {account_id}, Region: {region}")
 
     tak_infra_stack_name = f"TAK-{args.environment}-TakInfra"

--- a/scripts/takserver/test-bedrock-inference-profile.py
+++ b/scripts/takserver/test-bedrock-inference-profile.py
@@ -16,10 +16,15 @@ def test_bedrock_model(model_id, region="us-west-2"):
     # Create Bedrock Runtime client (same as Java SDK)
     client = boto3.client('bedrock-runtime', region_name=region)
     
-    # Prepare request body (matches BedrockChatManager.java format)
+    # Prepare request body (matches BedrockChatManager.java format).
+    # max_tokens=1000: models with extended/adaptive thinking enabled by
+    # default (e.g. Claude Opus 5) can consume the entire token budget on
+    # internal "thinking" content with no "text" block returned at low
+    # max_tokens (confirmed: 100 reliably produces a thinking-only response
+    # with stop_reason=max_tokens). 1000 leaves enough room for both.
     request_body = {
         "anthropic_version": "bedrock-2023-05-31",
-        "max_tokens": 100,
+        "max_tokens": 1000,
         "messages": [
             {
                 "role": "user",
@@ -35,11 +40,22 @@ def test_bedrock_model(model_id, region="us-west-2"):
             body=json.dumps(request_body)
         )
         
-        # Parse response
+        # Parse response. Search all content blocks for text rather than
+        # assuming content[0] is text -- models with thinking enabled may
+        # return a "thinking" block before the "text" block.
         response_body = json.loads(response['body'].read())
-        
+        text_blocks = [b.get("text") for b in response_body.get("content", []) if b.get("type") == "text"]
+
+        if not text_blocks:
+            print("✗ FAILED!")
+            print(f"No text block in response (stop_reason={response_body.get('stop_reason')}). "
+                  f"Content block types: {[b.get('type') for b in response_body.get('content', [])]}")
+            print("If stop_reason is 'max_tokens' with only a 'thinking' block, increase max_tokens.")
+            print("-" * 60)
+            return False
+
         print("✓ SUCCESS!")
-        print(f"Response: {response_body['content'][0]['text']}")
+        print(f"Response: {text_blocks[0]}")
         print("-" * 60)
         return True
         
@@ -55,8 +71,8 @@ if __name__ == "__main__":
     print()
     
     # Test inference profile
-    print("Test 1: Claude Sonnet 4 via inference profile")
-    success1 = test_bedrock_model("us.anthropic.claude-sonnet-4-6")
+    print("Test 1: Claude Sonnet 5 via inference profile")
+    success1 = test_bedrock_model("us.anthropic.claude-sonnet-5")
     print()
     
     # Test direct model (for comparison)
@@ -67,7 +83,7 @@ if __name__ == "__main__":
     # Summary
     print("=" * 60)
     print("SUMMARY:")
-    print(f"  Inference profile (Claude Sonnet 4): {'✓ WORKS' if success1 else '✗ FAILED'}")
+    print(f"  Inference profile (Claude Sonnet 5): {'✓ WORKS' if success1 else '✗ FAILED'}")
     print(f"  Direct model (Claude 3.5 Haiku):     {'✓ WORKS' if success2 else '✗ FAILED'}")
     print("=" * 60)
     


### PR DESCRIPTION
Four independent fixes/improvements from a Bedrock chatbot latency and reliability investigation:

Plugin manager startup crash (docker-container/scripts/start-tak.sh) configureInDocker.sh launches 5 TAK Server JVMs concurrently. Each one independently does an unsynchronized check-then-copy of TAKIgniteConfig.xml from TAKIgniteConfig.example.xml. The loser of that race hits FileAlreadyExistsException and exits immediately — observed in production to kill the plugin manager (takserver-pm.jar) on startup, silently disabling TAK-GPT until manually restarted. Fix: pre-create the file before any JVM launches, so every JVM's own check finds it already present and skips the copy. Eliminates the race by construction rather than reducing its odds.

UID-based chat addressing (plugins/tak-gpt) TAKChatBotBase used callsign (display-only, mutable, not guaranteed unique across devices) as the primary sender identity for LLM session/conversation-memory keying, with a broken fallback (a fresh random CoT event UID on every message) when callsign parsing failed. Switched to the sender's stable device UID (uid0 in <chatgrp>, with a WinTAK sourceID refinement), matching how ATAK/WinTAK/TAK Server themselves treat UID as canonical sender identity. Callsign is still used for what's shown to the LLM/user — unchanged.

Bedrock agent alias deploy gap (scripts/bedrock/setup-bedrock-agent.py) ensure_agent_alias() only returned the existing alias ID on reruns and never repointed it to a new version — DRAFT changes (model, instructions, KBs, action groups) never reached production traffic. This is what caused a Bedrock agent to keep serving Opus 5 in production despite the script being updated to Sonnet 5. Fix: call update_agent_alias with routingConfiguration omitted, which creates a new version from DRAFT and repoints the alias to it.

Model default: Sonnet 4.6 → Sonnet 5 CloudWatch InvocationLatency data showed Sonnet 5 (~7s avg) close to Sonnet 4.6 (~4-5s avg) and much better than Opus 5 (~17s avg) for this workload. Updated setup-bedrock-agent.py, test-bedrock-inference-profile.py, and 
TAK_GPT_PLUGIN.md
.

Dependency bump aws-cdk-lib 2.262.1→2.263.0, aws-cdk 2.1133.0→2.1134.0, constructs 10.7.1→10.8.0.

Testing
npm run build (tsc) — clean
Full Jest suite — 46/46 passing
cdk synth for both dev-test and prod contexts — succeeds, no errors
Plugin manager fix: reproduced the race locally (5 concurrent processes racing a check-then-copy) and confirmed pre-creating the file makes every subsequent check a no-op
tak-gpt plugin: built locally against the real TAK Server plugin API (extracted from the official distribution ZIP, same JARs the Docker image build uses) — ./gradlew :lib:clean :lib:shadowJar succeeds
Bedrock alias fix and Sonnet 5 swap: verified end-to-end against live Bedrock agents in the demo account (both SENTINEL and RELAY bots confirmed running Sonnet 5 in production with no forced-thinking override)