### PR TITLE
Fix tak-gpt reply routing leak + bump CDK to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "aws-cdk-lib": "^2.263.0",
         "axios": "^1.16.0",
-        "constructs": "^10.8.0",
+        "constructs": "^10.8.1",
         "form-data": "^4.0.1",
         "source-map-support": "^0.5.21"
       },
@@ -21,7 +21,7 @@
       "devDependencies": {
         "@types/jest": "^29.5.14",
         "@types/node": "22.20.0",
-        "aws-cdk": "^2.1134.0",
+        "aws-cdk": "^2.1135.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
@@ -1268,9 +1268,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.1134.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1134.0.tgz",
-      "integrity": "sha512-Fy/g+gdpMpkhAAoCNlZtX0s4mD7q58bHlDV6QfbnTeifmQ5cEge26c5rB+U4qKB/bDudxNuJjQk/mSSk0ysnug==",
+      "version": "2.1135.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1135.0.tgz",
+      "integrity": "sha512-Vfz2kllheB+8y9audOtcw0qo0v6EnjxfO2pK7x6eSulHmD0GaAvkqrg6MF+20wxE2KTyuY1UDBzICO+nHUaFtA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1643,9 +1643,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1901,9 +1901,9 @@
       }
     },
     "node_modules/constructs": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.8.0.tgz",
-      "integrity": "sha512-pJHp2CxvTG0ttp52rZvQfkbspPLZzttWPooIRLBwlZK8rV7ZhkjIkyZWJhIfBDC4YdcwIDmXyUFr1ieJaqjBbg==",
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.8.1.tgz",
+      "integrity": "sha512-98yGXYyhePqPYh3cYu8nzBERmAhC0DONe3UD03okK0nehZ7hYP4wgZuf02a04+uOWxnTJ5Rpp5m0GRNpwyLGGA==",
       "license": "Apache-2.0"
     },
     "node_modules/convert-source-map": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.14",
     "@types/node": "22.20.0",
-    "aws-cdk": "^2.1134.0",
+    "aws-cdk": "^2.1135.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
@@ -47,7 +47,7 @@
   },
   "overrides": {
     "handlebars": ">=4.7.9",
-    "brace-expansion": ">=5.0.8",
+    "brace-expansion": ">=5.0.9",
     "picomatch": ">=4.0.2",
     "yaml": ">=2.7.1",
     "follow-redirects": ">=1.16.0",
@@ -59,7 +59,7 @@
   "dependencies": {
     "aws-cdk-lib": "^2.263.0",
     "axios": "^1.16.0",
-    "constructs": "^10.8.0",
+    "constructs": "^10.8.1",
     "form-data": "^4.0.1",
     "source-map-support": "^0.5.21"
   }

--- a/plugins/tak-gpt/lib/src/main/java/tak/server/plugins/messages/TAKChatGenerator.java
+++ b/plugins/tak-gpt/lib/src/main/java/tak/server/plugins/messages/TAKChatGenerator.java
@@ -18,7 +18,16 @@ import tak.server.plugins.messaging.MessageConverter;
 
 public class TAKChatGenerator {
 	//private static final String CHAT_TEMPLATE = "<event version=\"2.0\" uid=\"GeoChat.|||UID|||\" type=\"b-t-f\" how=\"h-g-i-g-o\" time=\"|||TIME|||\" start=\"|||TIME|||\" stale=\"|||STALE|||\"><point lat=\"0.0\" lon=\"0.0\" hae=\"999999.0\" ce=\"999999.0\" le=\"999999.0\"/><detail><__chat parent="RootContactGroup" senderCallsign=\"TAKBot\" chatroom=\"|||DST_CALLSIGN|||\" id=\"|||ID|||\"><chatgrp id=\"|||ID|||\" uid1=\"|||UID1|||\" uid0=\"|||UID0|||\"/></__chat><remarks time=\"2024-02-07T05:02:41Z\" source=\"daf0e27b-1ba2-08db-992e-153a2c73ea4b\" to=\"1a677971-bfba-a731-f86b-64c2317f7097\">|||CHAT_TEXT|||</remarks><link relation=\"p-p\" type=\"a-f-G-U-C-I\" uid=\"TAKBot\"/><marti><dest callsign=\"|||DST_CALLSIGN|||\"/></marti></detail></event>";
-	private static final String CHAT_TEMPLATE = "<event version=\"2.0\" uid=\"GeoChat.|||SRC_UID|||.|||DST_UID|||.|||MSG_UID|||\" type=\"b-t-f\" how=\"h-g-i-g-o\" time=\"|||TIME|||\" start=\"|||TIME|||\" stale=\"|||STALE|||\"><point lat=\"0.0\" lon=\"0.0\" hae=\"9999999.0\" ce=\"9999999.0\" le=\"9999999.0\"/><detail><__chat parent=\"RootContactGroup\" messageId=\"|||MSG_UID|||\" senderCallsign=\"|||SRC_CALLSIGN|||\" chatroom=\"|||DST_CALLSIGN|||\" id=\"|||DST_UID|||\"><chatgrp id=\"|||DST_UID|||\" uid1=\"|||DST_UID|||\" uid0=\"|||SRC_UID|||\"/></__chat><remarks time=\"|||TIME|||\" to=\"|||DST_UID|||\">|||TEXT|||</remarks><link relation=\"p-p\" type=\"a-f-G-U-C-I\" uid=\"|||SRC_UID|||\"/></detail></event>";
+	// Includes <marti><dest uid="..."/></marti> so TAK Server routes this message via
+	// explicit UID-based brokering (DistributedSubscriptionManager.getExplicitUidMatches,
+	// which looks up SubscriptionStore.clientUidToSubMap) to exactly the one subscription
+	// for that device UID. Without it, the server falls back to implicit/group brokering
+	// (getImplicitMatches) and broadcasts the reply to every subscription reachable within
+	// the bot's CoT groups - e.g. delivering it to a CloudTAK session for the same user
+	// account even though the reply was addressed only to their ATAK device UID. Uses uid
+	// only (not callsign) since callsign is display-only and can collide/differ across a
+	// user's devices (see getSenderUid() comment above for the same rationale).
+	private static final String CHAT_TEMPLATE = "<event version=\"2.0\" uid=\"GeoChat.|||SRC_UID|||.|||DST_UID|||.|||MSG_UID|||\" type=\"b-t-f\" how=\"h-g-i-g-o\" time=\"|||TIME|||\" start=\"|||TIME|||\" stale=\"|||STALE|||\"><point lat=\"0.0\" lon=\"0.0\" hae=\"9999999.0\" ce=\"9999999.0\" le=\"9999999.0\"/><detail><__chat parent=\"RootContactGroup\" messageId=\"|||MSG_UID|||\" senderCallsign=\"|||SRC_CALLSIGN|||\" chatroom=\"|||DST_CALLSIGN|||\" id=\"|||DST_UID|||\"><chatgrp id=\"|||DST_UID|||\" uid1=\"|||DST_UID|||\" uid0=\"|||SRC_UID|||\"/></__chat><remarks time=\"|||TIME|||\" to=\"|||DST_UID|||\">|||TEXT|||</remarks><link relation=\"p-p\" type=\"a-f-G-U-C-I\" uid=\"|||SRC_UID|||\"/><marti><dest uid=\"|||DST_UID|||\"/></marti></detail></event>";
 	private static final Logger LOGGER = LoggerFactory.getLogger(TAKChatGenerator.class);
 	
 	public static Message generateChat(Message messageToReverse, String chatText, String botCallsign) throws Exception {


### PR DESCRIPTION
## Summary

Two independent changes bundled on this branch:

1. **Fix tak-gpt cross-client message leak** — chat bot replies were being
   delivered to unintended clients.
2. **Update CDK to latest version** — routine dependency bump.

## 1. tak-gpt: route chat replies via explicit dest UID

### Problem

When a user messaged the tak-gpt bot from ATAK, the bot's reply also showed
up in that same user's CloudTAK session — even though CloudTAK never sent
the original message and has a different client UID/callsign (same
account, different device).

### Root cause

`TAKChatGenerator.CHAT_TEMPLATE` builds the reply's `<chatgrp uid0/uid1>`
correctly, but was missing `<marti><dest uid="..."/></marti>`. That element
was present in an earlier version of the template and dropped during a
later fix (#91) without realizing its routing significance.

Without `marti/dest`, TAK Server's `DistributedSubscriptionManager` has no
explicit brokering target and falls back to implicit/group-based routing
(`getImplicitMatches`), which broadcasts the message to every subscription
reachable within the sender's CoT groups — not just the addressed UID. Any
other session sharing those groups (e.g. the same user's CloudTAK
connection) also receives it.

### Fix

Re-add `<marti><dest uid="|||DST_UID|||"/></marti>` to the reply template,
using UID only (not callsign, which is display-only and can differ/collide
across a user's devices — consistent with existing sender-UID handling in
`TAKChatBotBase`). This routes the reply via TAK Server's explicit
UID-based brokering (`getExplicitUidMatches` → `SubscriptionStore
.clientUidToSubMap`) to exactly the one subscription for that device.

### Verification

- Confirmed the only call site (`TAKChatBotBase.java`) always passes a
  real message, never `null`, so the unrelated `messageToReverse == null`
  branch is unaffected.
- Simulated template substitution locally and confirmed the resulting CoT
  event is well-formed XML, including UIDs containing dots (the
  CloudTAK-UID-truncation case fixed by #91).
- Could not run the plugin's Gradle build — it requires TAK.gov Maven
  credentials and the TAK Server SDK, only available during the Docker
  image build. No existing unit tests cover `TAKChatGenerator`.
- Full runtime verification (rebuild image, redeploy, repro against real
  ATAK + CloudTAK sessions) still needed post-merge.

### Follow-up (not in this PR)

CloudTAK's `ConnectionPool.cots()` also has no destination-UID check
before broadcasting a received chat message to all of an account's
browser sessions. This fix addresses the TAK Server-side root cause, but
CloudTAK should add a defense-in-depth check separately.

## 2. Update CDK to latest version

- `aws-cdk`: 2.1134.0 → 2.1135.0
- `constructs`: 10.8.0 → 10.8.1
- `brace-expansion` override: `>=5.0.8` → `>=5.0.9` (GHSA-rgw5-rvv9-x895)
- `aws-cdk-lib` already at latest (2.263.0), no change needed

Note: `npm audit` still flags `brace-expansion` 5.0.8 because it's bundled
inside `aws-cdk-lib`'s package (nested under its vendored `minimatch`),
which npm `overrides` can't patch. Resolves upstream once `aws-cdk-lib`
ships an updated bundle.

### Verification

- `npm install` clean, lockfile updated
- `npx cdk --version` → 2.1135.0
- `npm run build` (tsc) passes
- Full test suite: 46/46 passing across 9 suites
- Did not run `cdk synth`/`deploy` directly (requires AWS account
  context); CI only runs `tsc --noEmit` + tests, both of which pass

## Testing

- [x] `npm run build`
- [x] `npm run test` (46/46 passing)
- [ ] Manual repro: ATAK → tak-gpt → confirm reply no longer appears in
      CloudTAK session for the same user (post-deploy)
