### PR TITLE
feat(tak-server): CloudTAK OIDC discovery trust support

### DIFF
--- a/docker-container/scripts/createCoreConfig.sh
+++ b/docker-container/scripts/createCoreConfig.sh
@@ -362,20 +362,54 @@ substitute_template() {
 }
 
 # Generate OAuth section
+#
+# Emits the <oauth> wrapper around up to two trust entries:
+#   1. <authServer>                    -- classic OAuth2 (e.g. WebTAK's own
+#                                          Authentik application), keyed off
+#                                          TAKSERVER_CoreConfig_OAuthServer_*
+#   2. <openIdDiscoveryConfiguration>   -- a second OIDC provider trusted via
+#                                          discovery document (e.g. CloudTAK's
+#                                          separate Authentik application),
+#                                          keyed off
+#                                          TAKSERVER_CoreConfig_OIDCDiscovery_*
+#
+# Per CoreConfig.xsd's <oauth> xs:sequence, all <authServer> elements must
+# come before any <openIdDiscoveryConfiguration> elements -- order matters,
+# so authServer is always emitted first.
+#
+# The <oauth> wrapper (and usernameClaim, which is shared across both entries
+# per the schema) is only emitted if at least one of the two providers is
+# configured.
 generate_oauth_section() {
     local oauth_server_name=$(get_env_value "TAKSERVER_CoreConfig_OAuthServer_Name" "")
+    local discovery_name=$(get_env_value "TAKSERVER_CoreConfig_OIDCDiscovery_Name" "")
+
+    # Nothing configured at all -> no <oauth> block
+    if [[ -z "$oauth_server_name" && -z "$discovery_name" ]]; then
+        return
+    fi
+
+    echo "        <oauth usernameClaim=\"$(get_env_value "TAKSERVER_CoreConfig_OAuth_UsernameClaim" "preferred_username")\">"
 
     if [[ -n "$oauth_server_name" ]]; then
         local trust_all_certs=$(get_env_value "TAKSERVER_CoreConfig_OAuthServer_TrustAllCerts" "false" "boolean")
         local trust_attr=""
         [[ "$trust_all_certs" == "true" ]] && trust_attr=' trustAllCerts="true"'
-
         cat << EOF
-        <oauth usernameClaim="$(get_env_value "TAKSERVER_CoreConfig_OAuth_UsernameClaim" "preferred_username")">
             <authServer name="$oauth_server_name" issuer="$(get_env_value "TAKSERVER_CoreConfig_OAuthServer_Issuer" "")" clientId="$(get_env_value "TAKSERVER_CoreConfig_OAuthServer_ClientId" "")" secret="$(get_env_value "TAKSERVER_CoreConfig_OAuthServer_Secret" "")" redirectUri="$(get_env_value "TAKSERVER_CoreConfig_OAuthServer_RedirectUri" "")" scope="$(get_env_value "TAKSERVER_CoreConfig_OAuthServer_Scope" "")" authEndpoint="$(get_env_value "TAKSERVER_CoreConfig_OAuthServer_AuthEndpoint" "")" tokenEndpoint="$(get_env_value "TAKSERVER_CoreConfig_OAuthServer_TokenEndpoint" "")"$trust_attr/>
-        </oauth>
 EOF
     fi
+
+    if [[ -n "$discovery_name" ]]; then
+        local disc_trust_all=$(get_env_value "TAKSERVER_CoreConfig_OIDCDiscovery_TrustAllCerts" "false" "boolean")
+        local disc_trust_attr=""
+        [[ "$disc_trust_all" == "true" ]] && disc_trust_attr=' trustAllCerts="true"'
+        cat << EOF
+            <openIdDiscoveryConfiguration name="$discovery_name" clientId="$(get_env_value "TAKSERVER_CoreConfig_OIDCDiscovery_ClientId" "")" secret="$(get_env_value "TAKSERVER_CoreConfig_OIDCDiscovery_Secret" "")" redirectUri="$(get_env_value "TAKSERVER_CoreConfig_OIDCDiscovery_RedirectUri" "")" configurationUri="$(get_env_value "TAKSERVER_CoreConfig_OIDCDiscovery_ConfigurationUri" "")"$disc_trust_attr/>
+EOF
+    fi
+
+    echo "        </oauth>"
 }
 
 # Set commonly used values

--- a/docs/TAKSERVER_CORECONFIG.md
+++ b/docs/TAKSERVER_CORECONFIG.md
@@ -92,6 +92,14 @@ If `webtak.enableOidc` is not set (or the WebTAK OIDC secret doesn't exist),
 CDK does not set the OAuth variables above, and the S3 file's OAuth settings
 (if any) take effect normally.
 
+`TAKSERVER_CoreConfig_OIDCDiscovery_*` (see below) is **not** touched by CDK
+at all, in any configuration. It exists purely as an S3-config-file
+mechanism for trusting a second OIDC provider (e.g. CloudTAK's own Authentik
+application) alongside WebTAK's `<authServer>` entry, including its client
+secret -- there is no cross-stack CDK wiring for it, by design, since
+tak-infra has no way to resolve CloudTAK-owned values at deploy time and no
+requirement to.
+
 ## Configuration Reference
 
 Every variable below is actually read by `createCoreConfig.sh` via
@@ -167,6 +175,43 @@ WebTAK OIDC is enabled — see [precedence table](#precedence-s3-file-vs-cdk-con
 `TAKSERVER_CoreConfig_OAuthServer_JWKS` is used only by
 `getOIDCIssuerPubKey.sh` (to download and write the file referenced by
 `OAuthServer_Issuer`), not by `createCoreConfig.sh` directly.
+
+### OIDC Discovery Trust (`<auth><oauth><openIdDiscoveryConfiguration>`)
+
+A second, independent OIDC trust entry, resolved via a discovery document
+(`.well-known/openid-configuration`) rather than a manually-configured
+authorization/token endpoint pair. This is how TAK Server trusts bearer
+tokens signed by a *second* OIDC provider/application in addition to the
+`<authServer>` entry above -- e.g. CloudTAK has its own Authentik OIDC
+application (separate from WebTAK's), and needs TAK Server to trust its
+tokens for the `/Marti/api/tls/config` cert-enrollment M2M flow.
+
+This element is only generated if `TAKSERVER_CoreConfig_OIDCDiscovery_Name`
+is set. Unlike the WebTAK OAuth settings above, **none of these variables
+are ever set by CDK** -- this is purely an S3 `takserver-config.env`
+mechanism, including the client secret. Use it when running TAK Server with
+CloudTAK and you want TAK Server to trust CloudTAK's own Authentik OIDC
+application for its M2M cert-enrollment flow; leave it entirely unset when
+running without CloudTAK. If neither `OAuthServer_Name` nor
+`OIDCDiscovery_Name` is set, no `<oauth>` element is generated at all. If
+only one is set, the `<oauth>` element contains just that one entry. Per
+`CoreConfig.xsd`, `<authServer>` elements must precede
+`<openIdDiscoveryConfiguration>` elements within `<oauth>` --
+`createCoreConfig.sh` always emits them in that order regardless of which
+env vars are set.
+
+| Variable | Default | Effect |
+|---|---|---|
+| `TAKSERVER_CoreConfig_OIDCDiscovery_Name` | unset | Display name for this trust entry. Setting this triggers generation of the `<openIdDiscoveryConfiguration>` element |
+| `TAKSERVER_CoreConfig_OIDCDiscovery_ClientId` | empty | OIDC client ID |
+| `TAKSERVER_CoreConfig_OIDCDiscovery_Secret` | empty | OIDC client secret (required by the XSD even though it isn't exercised for bearer-token-only validation) |
+| `TAKSERVER_CoreConfig_OIDCDiscovery_RedirectUri` | empty | Redirect URI (required by the XSD; not exercised unless TAK Server's own authorization-code flow is used against this provider) |
+| `TAKSERVER_CoreConfig_OIDCDiscovery_ConfigurationUri` | empty | The provider's OIDC discovery document URI (`.../.well-known/openid-configuration`). TAK Server uses this to fetch the provider's live JWKS automatically |
+| `TAKSERVER_CoreConfig_OIDCDiscovery_TrustAllCerts` | `false` | Disable TLS certificate validation for this provider (development only) |
+
+`usernameClaim` (see the OAuth table above) is shared across both the
+`<authServer>` and `<openIdDiscoveryConfiguration>` entries -- it's an
+attribute of `<oauth>` itself, not per-provider.
 
 ### Federation
 

--- a/takserver-config.env.example
+++ b/takserver-config.env.example
@@ -149,6 +149,35 @@ TAKSERVER_CoreConfig_OAuthServer_TokenEndpoint=https://account.tak.nz/applicatio
 # NOT overridden by CDK -- always takes effect if OAuthServer_Name is set.
 TAKSERVER_CoreConfig_OAuthServer_TrustAllCerts=false
 
+# OIDC Discovery Trust (second, independent OIDC provider)
+#
+# A second OIDC trust entry, resolved via a discovery document instead of a
+# manually-configured auth/token endpoint pair -- e.g. for trusting a
+# separate application/provider (such as CloudTAK's own Authentik OIDC
+# application) for M2M bearer-token validation, in addition to the
+# OAuthServer entry above. See docs/TAKSERVER_CORECONFIG.md.
+#
+# NOTE: Unlike OAuthServer_* above, none of these settings are ever touched
+# by CDK -- this is purely an S3 config file mechanism, including the client
+# secret. Only set these if you're running TAK Server together with
+# CloudTAK and want TAK Server to trust CloudTAK's own OIDC application;
+# leave this whole block unset if not using CloudTAK.
+#
+# Setting OIDCDiscovery_Name triggers generation of the
+# <openIdDiscoveryConfiguration> element; if unset, none of the other
+# OIDCDiscovery settings below have any effect.
+# Default: unset
+TAKSERVER_CoreConfig_OIDCDiscovery_Name=CloudTAK
+
+TAKSERVER_CoreConfig_OIDCDiscovery_ClientId=abcdefg12345
+TAKSERVER_CoreConfig_OIDCDiscovery_Secret=mysupersecretsecret
+TAKSERVER_CoreConfig_OIDCDiscovery_RedirectUri=https://map.tak.nz/login/redirect
+TAKSERVER_CoreConfig_OIDCDiscovery_ConfigurationUri=https://account.tak.nz/application/o/cloudtak/.well-known/openid-configuration
+
+# Disable TLS certificate validation for this provider. Development only.
+# Valid: true, false | Default: false
+TAKSERVER_CoreConfig_OIDCDiscovery_TrustAllCerts=false
+
 # Federation Configuration
 #
 # Enables/disables the <federation> element and federation-server generation.

--- a/test/CoreConfig/test-createCoreConfig.sh
+++ b/test/CoreConfig/test-createCoreConfig.sh
@@ -312,6 +312,90 @@ run_test "Submission/Subscription Attributes" \
     "TAKSERVER_CoreConfig_Submission_ValidateXml=true" \
     "TAKSERVER_CoreConfig_Subscription_ReloadPersistent=true"
 
+# Test 14: OIDC Discovery Trust only (e.g. CloudTAK trust with no WebTAK OAuth)
+run_test "OIDC Discovery Trust Only" \
+    "TAKSERVER_CoreConfig_OIDCDiscovery_Name=CloudTAK" \
+    "TAKSERVER_CoreConfig_OIDCDiscovery_ClientId=discovery-client" \
+    "TAKSERVER_CoreConfig_OIDCDiscovery_Secret=discovery-secret" \
+    "TAKSERVER_CoreConfig_OIDCDiscovery_RedirectUri=https://map.example.com/login/redirect" \
+    "TAKSERVER_CoreConfig_OIDCDiscovery_ConfigurationUri=https://account.example.com/application/o/cloudtak/.well-known/openid-configuration"
+
+# Test 15: OAuthServer + OIDC Discovery Trust combined (WebTAK OAuth plus a
+# second, discovery-based provider trust, e.g. CloudTAK). Verifies both
+# <authServer> and <openIdDiscoveryConfiguration> are present, in the
+# schema-required order (authServer first).
+test_oauth_and_oidc_discovery_combined() {
+    local test_name="OAuthServer and OIDC Discovery Trust Combined"
+    TEST_COUNT=$((TEST_COUNT + 1))
+
+    echo "=== Test $TEST_COUNT: $test_name ==="
+
+    export PostgresUsername="testuser"
+    export PostgresPassword="testpass"
+    export PostgresURL="postgresql://localhost:5432/testdb"
+    local tak_version=$(grep -o '"version": "[^"]*"' "$SCRIPT_DIR/../../cdk.json" | head -1 | cut -d'"' -f4)
+    export TAK_VERSION="takserver-docker-${tak_version:-5.4-RELEASE-19}"
+    export LDAP_DN="dc=example,dc=com"
+    export LDAP_SECURE_URL="ldaps://ldap.example.com:636"
+    export LDAP_Password="ldappass"
+    export StackName="TestStack"
+    export TAKSERVER_CoreConfig_OAuthServer_Name="WebTAK Account"
+    export TAKSERVER_CoreConfig_OAuthServer_Issuer="/opt/tak/certs/files/oauth-public-key.pem"
+    export TAKSERVER_CoreConfig_OAuthServer_ClientId="webtak-client"
+    export TAKSERVER_CoreConfig_OAuthServer_Secret="webtak-secret"
+    export TAKSERVER_CoreConfig_OAuthServer_RedirectUri="https://ops.example.com/login/redirect"
+    export TAKSERVER_CoreConfig_OAuthServer_Scope="openid profile"
+    export TAKSERVER_CoreConfig_OAuthServer_AuthEndpoint="https://account.example.com/application/o/authorize/"
+    export TAKSERVER_CoreConfig_OAuthServer_TokenEndpoint="https://account.example.com/application/o/token/"
+    export TAKSERVER_CoreConfig_OIDCDiscovery_Name="CloudTAK"
+    export TAKSERVER_CoreConfig_OIDCDiscovery_ClientId="cloudtak-client"
+    export TAKSERVER_CoreConfig_OIDCDiscovery_Secret="cloudtak-secret"
+    export TAKSERVER_CoreConfig_OIDCDiscovery_RedirectUri="https://map.example.com/login/redirect"
+    export TAKSERVER_CoreConfig_OIDCDiscovery_ConfigurationUri="https://account.example.com/application/o/cloudtak/.well-known/openid-configuration"
+
+    TEST_DIR=$(mktemp -d)
+    cd "$TEST_DIR"
+    mkdir -p tmp/test-tak/certs/files
+
+    if ! bash "$SCRIPT_DIR/$CREATE_SCRIPT" "$TEST_DIR/CoreConfig.xml" > test_output.log 2>&1; then
+        echo "❌ FAIL: $test_name - Script execution failed"
+        cat test_output.log
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    else
+        # Both elements must be present, and authServer must appear before
+        # openIdDiscoveryConfiguration per CoreConfig.xsd's sequence order.
+        local auth_line=$(grep -n '<authServer ' "$TEST_DIR/CoreConfig.xml" | head -1 | cut -d: -f1)
+        local discovery_line=$(grep -n '<openIdDiscoveryConfiguration ' "$TEST_DIR/CoreConfig.xml" | head -1 | cut -d: -f1)
+
+        if [[ -z "$auth_line" || -z "$discovery_line" ]]; then
+            echo "❌ FAIL: $test_name - missing authServer or openIdDiscoveryConfiguration element"
+            FAIL_COUNT=$((FAIL_COUNT + 1))
+        elif [[ "$auth_line" -ge "$discovery_line" ]]; then
+            echo "❌ FAIL: $test_name - authServer must precede openIdDiscoveryConfiguration per XSD sequence"
+            FAIL_COUNT=$((FAIL_COUNT + 1))
+        elif cd "$SCRIPT_DIR" && ./validateConfig.sh "$TEST_DIR/CoreConfig.xml" > "$TEST_DIR/validation.log" 2>&1; then
+            echo "✅ PASS: $test_name"
+            PASS_COUNT=$((PASS_COUNT + 1))
+        else
+            echo "❌ FAIL: $test_name - XML validation failed"
+            cat "$TEST_DIR/validation.log"
+            FAIL_COUNT=$((FAIL_COUNT + 1))
+        fi
+    fi
+
+    rm -rf "$TEST_DIR"
+    unset TAKSERVER_CoreConfig_OAuthServer_Name TAKSERVER_CoreConfig_OAuthServer_Issuer \
+          TAKSERVER_CoreConfig_OAuthServer_ClientId TAKSERVER_CoreConfig_OAuthServer_Secret \
+          TAKSERVER_CoreConfig_OAuthServer_RedirectUri TAKSERVER_CoreConfig_OAuthServer_Scope \
+          TAKSERVER_CoreConfig_OAuthServer_AuthEndpoint TAKSERVER_CoreConfig_OAuthServer_TokenEndpoint \
+          TAKSERVER_CoreConfig_OIDCDiscovery_Name TAKSERVER_CoreConfig_OIDCDiscovery_ClientId \
+          TAKSERVER_CoreConfig_OIDCDiscovery_Secret TAKSERVER_CoreConfig_OIDCDiscovery_RedirectUri \
+          TAKSERVER_CoreConfig_OIDCDiscovery_ConfigurationUri
+    echo ""
+}
+
+test_oauth_and_oidc_discovery_combined
+
 # Test 14: Federation configuration is preserved across regeneration
 #
 # CoreConfig.xml is otherwise fully regenerated from the template + S3/CDK


### PR DESCRIPTION
## Summary

TAK Server currently trusts exactly one OIDC provider (Authentik's `tak-webtak` application, used for WebTAK's native SSO login). This adds support for a second, independent OIDC trust entry so TAK Server can also validate bearer tokens signed by CloudTAK's own separate Authentik OIDC application, letting CloudTAK call `/Marti/api/tls/config` (cert enrollment) with a bearer token instead of the current temporary-password workaround.

Root cause: CloudTAK's tokens are signed with `cloudtak`'s provider key, but `CoreConfig.xml`'s `<oauth>` block only had a trust entry for `tak-webtak`'s key, so TAK Server threw `InvalidBearerTokenException` in `OAuthAuthenticator.auth()`.

## Changes

- `docker-container/scripts/createCoreConfig.sh`: `generate_oauth_section()` now also emits an `<openIdDiscoveryConfiguration>` element, gated on `TAKSERVER_CoreConfig_OIDCDiscovery_*` env vars, discovery-based so it stays in sync with the provider's live JWKS automatically. Per `CoreConfig.xsd`'s sequence ordering, `<authServer>` is always emitted before `<openIdDiscoveryConfiguration>`.
- `docs/TAKSERVER_CORECONFIG.md`: documented the new variables and added an "OIDC Discovery Trust" section.
- `takserver-config.env.example`: added the new variable block, following the existing `OAuthServer_*` pattern.
- `test/CoreConfig/test-createCoreConfig.sh`: added tests for discovery-trust-only and combined-with-WebTAK-OAuth, including assertions on element ordering and XSD validity.

This is **purely an S3 `takserver-config.env` mechanism** — no CDK/TypeScript changes. CloudTAK's client ID, secret, redirect URI, and discovery URI are only known once CloudTAK is deployed (which happens after tak-infra), and are environment-specific, so they don't belong in version-controlled CDK context. Environments not running CloudTAK simply leave this block unset and get no `<openIdDiscoveryConfiguration>` element at all.

## Testing

- `bash test/CoreConfig/test-createCoreConfig.sh` — 17/17 pass
- `npx tsc --noEmit` — clean (no CDK code touched, verified no regressions)
- `npm test` — 46/46 pass
- Manually verified against live Authentik provider config in both Test and Demo environments; uploaded corresponding `takserver-config.env` files to each environment's S3 config bucket (not part of this PR — those files are gitignored and deployed out-of-band).

## Deployment note

Since `CoreConfig.xml` is regenerated on every container start, this change only takes effect after a TAK Server ECS task replacement in environments where the S3 config file is updated with the new `TAKSERVER_CoreConfig_OIDCDiscovery_*` values.