### PR TITLE
Fix duplicate cert detection in revoke-duplicate-certs.sh

### DIFF
--- a/docker-container/scripts/revoke-duplicate-certs.sh
+++ b/docker-container/scripts/revoke-duplicate-certs.sh
@@ -51,36 +51,38 @@ if [ -z "$ACTIVE_JSON" ]; then
 fi
 
 # Build user+device map to find duplicates
+# user_device_newest_date/id are only used to pick which cert to KEEP (the newest).
+# user_device_ids tracks every cert id seen for a key, independent of issuance_date,
+# so duplicate detection never depends on (or is broken by) the issuance date.
 declare -A user_device_newest_date
 declare -A user_device_newest_id
-declare -a all_active_certs
+declare -A user_device_ids
+total_active_certs=0
 
 while IFS='|' read -r id user_dn client_uid issuance_date; do
     [ -z "$id" ] || [ "$id" = "null" ] && continue
-    
+
     # Create unique key from user + device
     user_device_key="${user_dn}|${client_uid}"
-    all_active_certs+=("$id|$user_device_key|$issuance_date")
-    
+    total_active_certs=$((total_active_certs + 1))
+    user_device_ids[$user_device_key]+="$id "
+
     if [ -z "${user_device_newest_date[$user_device_key]:-}" ] || [[ "$issuance_date" > "${user_device_newest_date[$user_device_key]}" ]]; then
         user_device_newest_date[$user_device_key]="$issuance_date"
         user_device_newest_id[$user_device_key]="$id"
     fi
 done < <(echo "$ACTIVE_JSON" | jq -r '.data[] | select(.id != null and .userDn != null and .clientUid != null and .issuanceDate != null and .revocationDate == null) | "\(.id)|\(.userDn)|\(.clientUid)|\(.issuanceDate)"')
 
-echo "Found ${#all_active_certs[@]} active certificates"
+echo "Found $total_active_certs active certificates"
 echo "Found ${#user_device_newest_id[@]} unique user+device combinations"
 
-# Identify duplicates
+# Identify duplicates: every id for a key except the newest one is a duplicate.
 declare -a duplicates_to_revoke
-for cert_info in "${all_active_certs[@]}"; do
-    # cert_info format: "id|user_dn|client_uid|issuance_date"
-    # user_device_key is "user_dn|client_uid" so reconstruct by stripping first and last fields
-    id="${cert_info%%|*}"
-    issuance_date="${cert_info##*|}"
-    user_device_key="${cert_info#*|}"       # strip leading id|
-    user_device_key="${user_device_key%|*}" # strip trailing |issuance_date
-    [ "$id" != "${user_device_newest_id[$user_device_key]:-}" ] && duplicates_to_revoke+=("$id")
+for user_device_key in "${!user_device_ids[@]}"; do
+    newest_id="${user_device_newest_id[$user_device_key]}"
+    for id in ${user_device_ids[$user_device_key]}; do
+        [ "$id" != "$newest_id" ] && duplicates_to_revoke+=("$id")
+    done
 done
 
 if [ ${#duplicates_to_revoke[@]} -eq 0 ]; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -3372,9 +3372,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
`revoke-duplicate-certs.sh` identifies which active TAK Server certs are
duplicates (same user + device) and revokes all but the newest one. The
duplicate-matching logic was fragile and has been reworked.

## Problem
The script stored each cert as a single delimited string
(`id|user_dn|client_uid|issuance_date`) and later reconstructed the
user+device key by stripping the first and last `|`-delimited fields.
This breaks if `user_dn` or `client_uid` ever contains a literal `|`,
since the split points would shift and the reconstructed key would no
longer match the key used when recording the newest cert per user+device.
When that happens, duplicates for that entry silently stop being detected.

## Fix
- Track every cert ID per user+device key directly in a map as certs are
  read from the API response, instead of re-deriving the key later from a
  concatenated string.
- Duplicate detection now just diffs each key's list of IDs against the
  recorded "newest" ID for that key — no string parsing involved.
- `issuance_date` is only used to decide which single cert to keep (the
  newest); it plays no role in grouping/matching duplicates.

## Testing
- `bash -n` syntax check passes.
- Verified against mock JSON with a 3-cert duplicate group (same
  user+device, different issuance dates) plus two unrelated single certs:
  correctly kept the newest cert and flagged exactly the two older
  duplicates, leaving unrelated certs untouched.
- No live API testing was performed (would require a running TAK Server).

## Files changed
- `docker-container/scripts/revoke-duplicate-certs.sh`
- `package-lock.json` (unrelated dependency bump picked up during
  local install; included since it was part of the working tree diff)
