### PR TITLE
ci: fix Node.js 20 deprecation warnings in GitHub Actions

### DIFF
--- a/.github/actions/setup-cdk/action.yml
+++ b/.github/actions/setup-cdk/action.yml
@@ -17,7 +17,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@v7
       with:
         node-version: '22'
         cache: 'npm'

--- a/.github/actions/setup-cdk/action.yml
+++ b/.github/actions/setup-cdk/action.yml
@@ -17,13 +17,13 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '22'
         cache: 'npm'
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
         aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/cdk-test.yml
+++ b/.github/workflows/cdk-test.yml
@@ -29,7 +29,7 @@ jobs:
       - run: echo "👾 Repository is ${{ github.repository }}."
       
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -40,7 +40,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libxml2-utils
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
             node-version: '22'
             registry-url: https://registry.npmjs.org/

--- a/.github/workflows/cdk-test.yml
+++ b/.github/workflows/cdk-test.yml
@@ -29,7 +29,7 @@ jobs:
       - run: echo "👾 Repository is ${{ github.repository }}."
       
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -40,7 +40,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libxml2-utils
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
             node-version: '22'
             registry-url: https://registry.npmjs.org/

--- a/.github/workflows/demo-build.yml
+++ b/.github/workflows/demo-build.yml
@@ -37,7 +37,7 @@ jobs:
       tak-tag: ${{ steps.tags.outputs.tak-tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk

--- a/.github/workflows/demo-build.yml
+++ b/.github/workflows/demo-build.yml
@@ -37,7 +37,7 @@ jobs:
       tak-tag: ${{ steps.tags.outputs.tak-tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk

--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -35,7 +35,7 @@ jobs:
     needs: [test]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk
@@ -67,7 +67,7 @@ jobs:
       tak-tag: ${{ needs.build-images.outputs.tak-tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk
@@ -110,7 +110,7 @@ jobs:
     if: always()
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk

--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -35,7 +35,7 @@ jobs:
     needs: [test]
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk
@@ -67,7 +67,7 @@ jobs:
       tak-tag: ${{ needs.build-images.outputs.tak-tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk
@@ -110,7 +110,7 @@ jobs:
     if: always()
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -35,7 +35,7 @@ jobs:
       tak-tag: ${{ steps.tags.outputs.tak-tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -35,7 +35,7 @@ jobs:
       tak-tag: ${{ steps.tags.outputs.tak-tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -29,7 +29,7 @@ jobs:
     needs: [test, build-images]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -29,7 +29,7 @@ jobs:
     needs: [test, build-images]
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Fetch full history for changelog generation
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Fetch full history for changelog generation
 
@@ -62,7 +62,7 @@ jobs:
           echo "🚀 **Deployment:** This release will trigger production deployment after approval." >> RELEASE_NOTES.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           body_path: RELEASE_NOTES.md
           generate_release_notes: true  # GitHub will append auto-generated notes


### PR DESCRIPTION
## Summary

GitHub Actions flagged several workflow runs with Node.js 20 deprecation
warnings, since actions/checkout@v4, actions/setup-node@v4, and
aws-actions/configure-aws-credentials@v4 are pinned to versions that still
target the deprecated Node 20 runtime. This bumps all third-party actions
to their Node 24-native majors across every workflow and the shared
setup-cdk composite action.

- actions/checkout: v4 -> v7
- actions/setup-node: v4 -> v7
- aws-actions/configure-aws-credentials: v4 -> v6
- softprops/action-gh-release: v2 -> v3 (also still Node 20-based,
  caught while auditing all workflows for similar issues)

## Why v7 / v6 and not an intermediate version

Checked each major's breaking changes against how this repo actually
uses these actions:

- checkout v7 blocks fork PR checkout for `pull_request_target` /
  `workflow_run` triggers by default. None of our workflows use those
  triggers (only `push`, `pull_request`, `workflow_dispatch`,
  `workflow_call`), so this has no effect.
- setup-node v7 removes the `NODE_AUTH_TOKEN` dummy fallback. Only
  cdk-test.yml sets `registry-url`, and we only run `npm ci` against
  the public registry (package is `private: true`, no publish step,
  no `NODE_AUTH_TOKEN` referenced anywhere). No effect.
- aws-actions/configure-aws-credentials v6 and softprops/action-gh-release
  v3 breaking changes (node24 runtime bump) don't affect our usage
  either.

## Testing

- Validated YAML syntax for all changed workflow/action files with
  `python3 -c "import yaml; yaml.safe_load(...)"`.
- Not able to trigger a live Actions run from this environment; the
  Node 24 deprecation warning and any behavioral changes should be
  confirmed on the next CI run for this branch/PR.

## Files changed

- .github/actions/setup-cdk/action.yml
- .github/workflows/cdk-test.yml
- .github/workflows/demo-build.yml
- .github/workflows/demo-deploy.yml
- .github/workflows/production-build.yml
- .github/workflows/production-deploy.yml
- .github/workflows/release.yml
